### PR TITLE
Move wrapper class to Carousel and tweak styles

### DIFF
--- a/client/components/pages/about/project-team/ProjectTeam.tsx
+++ b/client/components/pages/about/project-team/ProjectTeam.tsx
@@ -54,28 +54,27 @@ export const ProjectTeam: React.FC = () => {
     ]
 
     return (
-        <div className={styles.section}>
-            <Carousel
-                options={{ dragFree: true, loop: true }}
-                autoScroll={true}
-            >
-                {teamList?.map((item) => (
-                    <div
-                        key={item.name}
-                        className={styles.item}
-                        role={'listitem'}
-                    >
-                        <Image
-                            className={styles.photo}
-                            src={item.photo?.src || ''}
-                            alt={item?.name || ''}
-                            width={item.photo?.width}
-                            height={item.photo?.height}
-                        />
-                        <div className={styles.title}>{item.name}</div>
-                    </div>
-                ))}
-            </Carousel>
-        </div>
+        <Carousel
+            options={{ dragFree: true, loop: true }}
+            autoScroll={true}
+            className={styles.carousel}
+        >
+            {teamList?.map((item) => (
+                <div
+                    key={item.name}
+                    className={styles.item}
+                    role={'listitem'}
+                >
+                    <Image
+                        className={styles.photo}
+                        src={item.photo?.src || ''}
+                        alt={item?.name || ''}
+                        width={item.photo?.width}
+                        height={item.photo?.height}
+                    />
+                    <div className={styles.title}>{item.name}</div>
+                </div>
+            ))}
+        </Carousel>
     )
 }

--- a/client/components/pages/about/project-team/styles.module.sass
+++ b/client/components/pages/about/project-team/styles.module.sass
@@ -1,16 +1,11 @@
-.section
-    //display: flex
-    //flex-wrap: nowrap
-    //justify-content: center
+.carousel
     width: 100%
     margin-top: 10px
-    //gap: 20px
-    //overflow: hidden
-    //overflow-x: scroll
 
     .item
         text-align: center
         margin-bottom: 10px
+        max-width: 190px !important
 
         .photo
             width: 160px

--- a/client/pages/starmap.tsx
+++ b/client/pages/starmap.tsx
@@ -7,7 +7,6 @@ import { serverSideTranslations } from 'next-i18next/serverSideTranslations'
 import { API, setLocale, wrapper } from '@/api'
 import { AppLayout, StarMap } from '@/components/common'
 
-// TODO: При добавить URL параметр названия объекта для центрирования карты на нем
 const CelestialPage: NextPage<object> = () => {
     const { t } = useTranslation()
 


### PR DESCRIPTION
Remove the extra wrapper div around the project team Carousel and pass styles.carousel as a className to the Carousel component. Rename .section to .carousel in the SASS, add a max-width to .item to constrain avatar sizing, and keep photo width at 160px. Also remove a stale TODO comment from starmap.tsx.