### PR TITLE
Release v4.5.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # CHANGELOG
 
+## 4.5.5
+
+### Patch Changes
+
+- Enhanced SEO metadata in `AppLayout`: canonical URL is now computed from `SITE_LINK` + path and honored even when set to an empty string; added `languageAlternates` (ru, en, x-default) when a canonical is present; set Open Graph type to `"website"` and default Twitter card to `"summary_large_image"`
+- Added `BreadcrumbList` JSON-LD structured data to `AppToolbar`: breadcrumb URLs are built with locale prefix (`en/` for English), home title is translated, and the schema is injected into `<Head>` via `dangerouslySetInnerHTML`
+- Added `Organization` JSON-LD structured data in `_app.tsx` (name, URL, logo, sameAs links); added canonical prop to the homepage; added homepage URL nodes (`''` and `en/`) to the sitemap with monthly cadence; extended `robots.txt` with Disallow rules for English routes, profile/unsubscribe pages, and stargazing statistic paths
+- Added schema.org `Event` JSON-LD to stargazing event detail pages (`/stargazing/[name]`): includes name, description, startDate, location, organizer, image, and URL; injected via `next/head` when event data is available
+- Added schema.org `FAQPage` JSON-LD to the stargazing FAQ page (`/stargazing/faq`): built from localized translation strings and injected via `next/head`
+- Extended `AuthGuardTest` with additional 401 checks covering photos (`PATCH`/`DELETE`), events (`POST`/`PATCH`/`DELETE`), comments (`POST`/`DELETE`), members endpoints, and mailings (`POST`/`DELETE`)
+- Added `CategoryEntityTest` and `EventPhotoEntityTest`: verify attribute casting, default values, datamap aliases, and that `created_at`/`updated_at`/`deleted_at` are included in the dates list
+- Added `MailingEmailEntityTest`, `ObjectEntityTest`, and `ObjectFitsFileEntityTest`: cover constant values, default attributes, type casting, date field inclusion, and datamap aliases
+- Added `PhotoEntityTest`, `ObservatoryEquipmentEntityTest`, and `ObjectFitsFiltersEntityTest`: verify int/float/string casts, default values for new instances, and datamap alias behavior
+- Expanded `AuthHelperTest` with edge-case coverage: `generateAuthToken` produces different tokens for different emails; `validateAuthToken` returns `null` for `null`, empty, malformed, or arbitrary non-JWT strings
+- Extended `ApplicationBaseModelTest` with tests for `prepareOutput` field-hiding (`first`/`findAll`) and `generateId` uniqueness and overwrite behavior; added `CommentsModelTest` (reflection-based, no DB) covering private helpers `truncateAuthorName` (empty, whitespace, single/multi-word, Cyrillic, initials) and `formatRows` (camelCase mapping, author object, avatar URL, raw DB field removal, `keepEntity` flag, multi-row formatting)
+
 ## 4.5.4
 
 ### Patch Changes

--- a/client/components/common/app-layout/AppLayout.tsx
+++ b/client/components/common/app-layout/AppLayout.tsx
@@ -31,6 +31,7 @@ export const AppLayout: React.FC<AppLayoutProps> = ({ fullWidth, children, ...pr
     const [sidebarOpen, setSidebarOpen] = useState<boolean>(false)
 
     const canonicalUrl = SITE_LINK + (i18n.language === 'en' ? 'en/' : '')
+    const pageUrl = canonicalUrl + (props?.canonical ?? '')
 
     const handleCloseOverlay = () => {
         setSidebarOpen(false)
@@ -61,11 +62,25 @@ export const AppLayout: React.FC<AppLayoutProps> = ({ fullWidth, children, ...pr
             <Head>
                 {generateNextSeo({
                     ...props,
-                    canonical: props?.canonical ? `${canonicalUrl}${props.canonical}` : undefined,
+                    canonical: props?.canonical !== undefined ? pageUrl : undefined,
+                    languageAlternates:
+                        props?.canonical !== undefined
+                            ? [
+                                  { hrefLang: 'ru', href: `${SITE_LINK}${props.canonical ?? ''}` },
+                                  { hrefLang: 'en', href: `${SITE_LINK}en/${props.canonical ?? ''}` },
+                                  { hrefLang: 'x-default', href: `${SITE_LINK}${props.canonical ?? ''}` }
+                              ]
+                            : undefined,
                     openGraph: {
+                        url: props?.canonical !== undefined ? pageUrl : undefined,
+                        type: 'website',
                         images: props?.openGraph?.images,
                         siteName: t('common.look-at-the-stars', 'Смотри на звёзды'),
                         locale: i18n.language === 'ru' ? 'ru_RU' : 'en_US'
+                    },
+                    twitter: {
+                        cardType: 'summary_large_image',
+                        ...props?.twitter
                     }
                 })}
             </Head>

--- a/client/components/common/app-toolbar/AppToolbar.tsx
+++ b/client/components/common/app-toolbar/AppToolbar.tsx
@@ -1,7 +1,9 @@
 import React, { forwardRef } from 'react'
 
+import Head from 'next/head'
 import { useTranslation } from 'next-i18next/pages'
 
+import { SITE_LINK } from '@/api'
 import { BreadcrumbLink, Breadcrumbs, BreadcrumbsProps } from '@/components/ui'
 
 import '@/api/applicationSlice'
@@ -16,25 +18,66 @@ interface AppToolbarProps extends Pick<BreadcrumbsProps, 'currentPage' | 'links'
 
 export const AppToolbar = forwardRef<HTMLDivElement, AppToolbarProps>(
     ({ title, links, currentPage, children }, ref) => {
-        const { t } = useTranslation()
+        const { t, i18n } = useTranslation()
+
+        const localePrefix = i18n.language === 'en' ? 'en/' : ''
+        const baseUrl = `${SITE_LINK ?? ''}${localePrefix}`
+
+        const breadcrumbItems: Array<{ name: string; item?: string }> = [
+            { name: t('common.look-at-the-stars', 'Смотри на звёзды'), item: SITE_LINK }
+        ]
+
+        if (links?.length) {
+            for (const { link, text } of links) {
+                breadcrumbItems.push({
+                    name: text,
+                    item: `${baseUrl}${link.replace(/^\//, '')}`
+                })
+            }
+        }
+
+        if (currentPage) {
+            breadcrumbItems.push({ name: currentPage })
+        }
+
+        const breadcrumbJsonLd = {
+            '@context': 'https://schema.org',
+            '@type': 'BreadcrumbList',
+            itemListElement: breadcrumbItems.map((item, index) => ({
+                '@type': 'ListItem',
+                position: index + 1,
+                name: item.name,
+                ...(item.item ? { item: item.item } : {})
+            }))
+        }
 
         return (
-            <div
-                className={styles.toolbarHeader}
-                ref={ref}
-            >
-                <div className={styles.toolbarTitle}>
-                    <h1>{title}</h1>
-                    {(links || currentPage) && (
-                        <Breadcrumbs
-                            links={links}
-                            currentPage={currentPage}
-                            homePageTitle={t('common.look-at-the-stars', 'Смотри на звёзды')}
+            <>
+                {(links || currentPage) && (
+                    <Head>
+                        <script
+                            type={'application/ld+json'}
+                            dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbJsonLd) }}
                         />
-                    )}
+                    </Head>
+                )}
+                <div
+                    className={styles.toolbarHeader}
+                    ref={ref}
+                >
+                    <div className={styles.toolbarTitle}>
+                        <h1>{title}</h1>
+                        {(links || currentPage) && (
+                            <Breadcrumbs
+                                links={links}
+                                currentPage={currentPage}
+                                homePageTitle={t('common.look-at-the-stars', 'Смотри на звёзды')}
+                            />
+                        )}
+                    </div>
+                    {children && <div className={styles.toolbarActions}>{children}</div>}
                 </div>
-                {children && <div className={styles.toolbarActions}>{children}</div>}
-            </div>
+            </>
         )
     }
 )

--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,7 @@
 {
     "name": "astronomy-portal",
     "description": "This project is intended for remote control of an amateur astronomical observatory. With the help of the WEB interface, you can control the power supply of the observatory devices, monitor the voltage, power current, as well as temperature and humidity in several places.",
-    "version": "4.5.4",
+    "version": "4.5.5",
     "engines": {
         "node": ">=20.11.0"
     },

--- a/client/pages/_app.tsx
+++ b/client/pages/_app.tsx
@@ -8,7 +8,7 @@ import { useRouter } from 'next/router'
 import Script from 'next/script'
 import { appWithTranslation, useTranslation } from 'next-i18next/pages'
 
-import { wrapper } from '@/api'
+import { SITE_LINK, wrapper } from '@/api'
 import { LOCAL_STORAGE } from '@/utils/constants'
 import * as LocalStorage from '@/utils/localstorage'
 
@@ -108,6 +108,19 @@ const App = ({ Component, pageProps }: AppProps) => {
                 <link
                     rel={'manifest'}
                     href={'/site.webmanifest'}
+                />
+                <script
+                    type={'application/ld+json'}
+                    dangerouslySetInnerHTML={{
+                        __html: JSON.stringify({
+                            '@context': 'https://schema.org',
+                            '@type': 'Organization',
+                            name: 'Смотри на звёзды',
+                            url: SITE_LINK?.replace(/\/$/, ''),
+                            logo: `${SITE_LINK}android-chrome-192x192.png`,
+                            sameAs: ['https://t.me/look_at_stars']
+                        })
+                    }}
                 />
             </Head>
 

--- a/client/pages/index.tsx
+++ b/client/pages/index.tsx
@@ -66,6 +66,7 @@ const HomePage: NextPage<HomePageProps> = ({ photosList }) => {
     return (
         <AppLayout
             fullWidth={true}
+            canonical={''}
             title={t('pages.index.title', 'Проект "Смотри на звёзды"')}
             description={t(
                 'pages.index.description',

--- a/client/pages/sitemap.tsx
+++ b/client/pages/sitemap.tsx
@@ -62,6 +62,10 @@ export const getServerSideProps = wrapper.getServerSideProps(
             </url>
           `
 
+            // Homepage
+            sitemap += makeUrlNode('', new Date('2025-01-01').toISOString(), 'monthly', '1.0')
+            sitemap += makeUrlNode('en/', new Date('2025-01-01').toISOString(), 'monthly', '1.0')
+
             // Static RU Locale
             sitemap += staticPages.map((url) => makeUrlNode(url, new Date().toISOString(), 'monthly', '0.8')).join('')
 

--- a/client/pages/stargazing/[name].tsx
+++ b/client/pages/stargazing/[name].tsx
@@ -3,12 +3,13 @@ import { getCookie } from 'cookies-next'
 import { Button, Container, Icon } from 'simple-react-ui-kit'
 
 import { GetServerSidePropsResult, NextPage } from 'next'
+import Head from 'next/head'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { useTranslation } from 'next-i18next/pages'
 import { serverSideTranslations } from 'next-i18next/pages/serverSideTranslations'
 
-import { API, ApiModel, setLocale, useAppSelector, wrapper } from '@/api'
+import { API, ApiModel, setLocale, SITE_LINK, useAppSelector, wrapper } from '@/api'
 import { setSSRToken } from '@/api/authSlice'
 import { hosts } from '@/api/constants'
 import { AppFooter, AppLayout, AppToolbar, PhotoGallery, PhotoLightbox } from '@/components/common'
@@ -44,6 +45,37 @@ const StargazingItemPage: NextPage<StargazingItemPageProps> = ({ eventId, event,
     const PHOTOS_PREVIEW_LIMIT = 12
 
     const title = `${t('menu.stargazing', 'Астровыезды')} - ${event?.title}`
+
+    const eventJsonLd = event
+        ? {
+              '@context': 'https://schema.org',
+              '@type': 'Event',
+              name: event.title,
+              description: sliceText(removeMarkdown(event.content ?? ''), 300),
+              startDate: event.date?.date,
+              eventStatus: 'https://schema.org/EventScheduled',
+              eventAttendanceMode: 'https://schema.org/OfflineEventAttendanceMode',
+              location: {
+                  '@type': 'Place',
+                  name: event.location ?? 'Оренбургская область',
+                  address: {
+                      '@type': 'PostalAddress',
+                      addressLocality: 'Оренбург',
+                      addressCountry: 'RU'
+                  }
+              },
+              organizer: {
+                  '@type': 'Organization',
+                  name: 'Смотри на звёзды',
+                  url: SITE_LINK?.replace(/\/$/, '')
+              },
+              image:
+                  event.coverFileName && event.coverFileExt
+                      ? `${hosts.stargazing}${event.id}/${event.coverFileName}_preview.${event.coverFileExt}`
+                      : undefined,
+              url: `${SITE_LINK}stargazing/${event.id}`
+          }
+        : null
 
     const adjacentEvents = useMemo(() => {
         const sortedEvents = [...(eventsList || [])].sort((a, b) => {
@@ -90,171 +122,182 @@ const StargazingItemPage: NextPage<StargazingItemPageProps> = ({ eventId, event,
     }, [photos])
 
     return (
-        <AppLayout
-            canonical={`stargazing/${event?.id}`}
-            title={title}
-            description={sliceText(removeMarkdown(event?.content || ''), 300)}
-            openGraph={{
-                images: [
-                    {
-                        height: 400,
-                        url: `${hosts.stargazing}${event?.id}/${event?.coverFileName}_preview.${event?.coverFileExt}`,
-                        width: 500
-                    }
-                ]
-            }}
-        >
-            <AppToolbar
+        <>
+            {eventJsonLd && (
+                <Head>
+                    <script
+                        type={'application/ld+json'}
+                        dangerouslySetInnerHTML={{ __html: JSON.stringify(eventJsonLd) }}
+                    />
+                </Head>
+            )}
+            <AppLayout
+                canonical={`stargazing/${event?.id}`}
                 title={title}
-                currentPage={event?.title}
-                links={[
-                    {
-                        link: '/stargazing',
-                        text: t('menu.stargazing', 'Астровыезды')
-                    }
-                ]}
+                description={sliceText(removeMarkdown(event?.content || ''), 300)}
+                openGraph={{
+                    images: [
+                        {
+                            height: 400,
+                            url: `${hosts.stargazing}${event?.id}/${event?.coverFileName}_preview.${event?.coverFileExt}`,
+                            width: 500
+                        }
+                    ]
+                }}
             >
-                {(userRole === ApiModel.UserRole.ADMIN || userRole === ApiModel.UserRole.MODERATOR) && (
-                    <>
-                        {userRole === ApiModel.UserRole.ADMIN && (
-                            <>
-                                <Button
-                                    disabled={!!uploadingPhotos?.length}
-                                    icon={'Download'}
-                                    mode={'secondary'}
-                                    onClick={handleUploadPhotoClick}
-                                >
-                                    {!uploadingPhotos?.length
-                                        ? 'Загрузить фотографии'
-                                        : `Загрузка ${uploadingPhotos?.length} фото`}
-                                </Button>
+                <AppToolbar
+                    title={title}
+                    currentPage={event?.title}
+                    links={[
+                        {
+                            link: '/stargazing',
+                            text: t('menu.stargazing', 'Астровыезды')
+                        }
+                    ]}
+                >
+                    {(userRole === ApiModel.UserRole.ADMIN || userRole === ApiModel.UserRole.MODERATOR) && (
+                        <>
+                            {userRole === ApiModel.UserRole.ADMIN && (
+                                <>
+                                    <Button
+                                        disabled={!!uploadingPhotos?.length}
+                                        icon={'Download'}
+                                        mode={'secondary'}
+                                        onClick={handleUploadPhotoClick}
+                                    >
+                                        {!uploadingPhotos?.length
+                                            ? 'Загрузить фотографии'
+                                            : `Загрузка ${uploadingPhotos?.length} фото`}
+                                    </Button>
 
-                                <Button
-                                    icon={'Pencil'}
-                                    mode={'secondary'}
-                                    label={t('common.edit', 'Редактировать')}
-                                    disabled={!eventId}
-                                    onClick={() => router.push(`/stargazing/form?id=${eventId}`)}
-                                />
-                            </>
-                        )}
+                                    <Button
+                                        icon={'Pencil'}
+                                        mode={'secondary'}
+                                        label={t('common.edit', 'Редактировать')}
+                                        disabled={!eventId}
+                                        onClick={() => router.push(`/stargazing/form?id=${eventId}`)}
+                                    />
+                                </>
+                            )}
 
-                        <Button
-                            icon={'BarChart'}
-                            mode={'secondary'}
-                            onClick={() => router.push(`/stargazing/${eventId}/statistic`)}
-                        />
-                    </>
-                )}
-            </AppToolbar>
+                            <Button
+                                icon={'BarChart'}
+                                mode={'secondary'}
+                                onClick={() => router.push(`/stargazing/${eventId}/statistic`)}
+                            />
+                        </>
+                    )}
+                </AppToolbar>
 
-            <EventItemData
-                title={title}
-                event={event || undefined}
-            />
+                <EventItemData
+                    title={title}
+                    event={event || undefined}
+                />
 
-            <h2>{`${event?.title} - ${t('pages.stargazing.photos-from-stargazing', 'Фотографии с астровыезда')}`}</h2>
+                <h2>{`${event?.title} - ${t('pages.stargazing.photos-from-stargazing', 'Фотографии с астровыезда')}`}</h2>
 
-            <Container>
-                {localPhotos?.length > 0 ? (
-                    <>
-                        <PhotoGallery
-                            photos={(isPhotosExpanded ? localPhotos : localPhotos.slice(0, PHOTOS_PREVIEW_LIMIT)).map(
-                                (photo, index) => ({
+                <Container>
+                    {localPhotos?.length > 0 ? (
+                        <>
+                            <PhotoGallery
+                                photos={(isPhotosExpanded
+                                    ? localPhotos
+                                    : localPhotos.slice(0, PHOTOS_PREVIEW_LIMIT)
+                                ).map((photo, index) => ({
                                     height: photo.height,
                                     src: createPreviewPhotoUrl(photo),
                                     width: photo.width,
                                     alt: `${photo?.title} (${t('pages.stargazing.photo', 'Фото')} ${index + 1})`
-                                })
+                                }))}
+                                onClick={({ index }) => {
+                                    handlePhotoClick(index)
+                                }}
+                            />
+
+                            {localPhotos.length > PHOTOS_PREVIEW_LIMIT && (
+                                <Button
+                                    mode={'secondary'}
+                                    className={styles.showMorePhotos}
+                                    onClick={() => setIsPhotosExpanded(!isPhotosExpanded)}
+                                >
+                                    {isPhotosExpanded
+                                        ? t('pages.stargazing.photos-show-less', 'Показать меньше фотографий')
+                                        : t('pages.stargazing.photos-show-all', 'Показать все {{count}} фотографий', {
+                                              count: localPhotos.length
+                                          })}
+                                </Button>
                             )}
-                            onClick={({ index }) => {
-                                handlePhotoClick(index)
-                            }}
-                        />
+                        </>
+                    ) : (
+                        <p className={styles.noPhotos}>
+                            {t(
+                                'pages.stargazing.no-photos',
+                                'Фотографии с этого события ещё не загружены. Загляните позже!'
+                            )}
+                        </p>
+                    )}
 
-                        {localPhotos.length > PHOTOS_PREVIEW_LIMIT && (
-                            <Button
-                                mode={'secondary'}
-                                className={styles.showMorePhotos}
-                                onClick={() => setIsPhotosExpanded(!isPhotosExpanded)}
-                            >
-                                {isPhotosExpanded
-                                    ? t('pages.stargazing.photos-show-less', 'Показать меньше фотографий')
-                                    : t('pages.stargazing.photos-show-all', 'Показать все {{count}} фотографий', {
-                                          count: localPhotos.length
-                                      })}
-                            </Button>
-                        )}
-                    </>
-                ) : (
-                    <p className={styles.noPhotos}>
-                        {t(
-                            'pages.stargazing.no-photos',
-                            'Фотографии с этого события ещё не загружены. Загляните позже!'
-                        )}
-                    </p>
-                )}
+                    <EventPhotoUploader
+                        eventId={eventId}
+                        fileInputRef={inputFileRef}
+                        onSelectFiles={setUploadingPhotos}
+                        onUploadPhoto={(photo) => {
+                            setLocalPhotos([...localPhotos, photo])
+                        }}
+                    />
+                </Container>
 
-                <EventPhotoUploader
-                    eventId={eventId}
-                    fileInputRef={inputFileRef}
-                    onSelectFiles={setUploadingPhotos}
-                    onUploadPhoto={(photo) => {
-                        setLocalPhotos([...localPhotos, photo])
-                    }}
+                <PhotoLightbox
+                    photos={localPhotos?.map((photo, index) => ({
+                        height: photo.height,
+                        src: createFullPhotoUrl(photo),
+                        width: photo.width,
+                        title: `${photo.title} (${t('pages.stargazing.photo', 'Фото')} ${index + 1})`
+                    }))}
+                    photoIndex={photoIndex}
+                    showLightbox={showLightbox}
+                    onCloseLightBox={handleCloseLightbox}
                 />
-            </Container>
 
-            <PhotoLightbox
-                photos={localPhotos?.map((photo, index) => ({
-                    height: photo.height,
-                    src: createFullPhotoUrl(photo),
-                    width: photo.width,
-                    title: `${photo.title} (${t('pages.stargazing.photo', 'Фото')} ${index + 1})`
-                }))}
-                photoIndex={photoIndex}
-                showLightbox={showLightbox}
-                onCloseLightBox={handleCloseLightbox}
-            />
+                <h2>{t('pages.stargazing.reviews', 'Отзывы')}</h2>
 
-            <h2>{t('pages.stargazing.reviews', 'Отзывы')}</h2>
+                <EventReviews eventId={eventId} />
 
-            <EventReviews eventId={eventId} />
-
-            <section className={styles.footerLinks}>
-                {adjacentEvents?.previousEvent && (
-                    <Link
-                        href={`/stargazing/${adjacentEvents?.previousEvent?.id}`}
-                        title={adjacentEvents?.previousEvent?.title}
-                    >
-                        <Icon name={'KeyboardLeft'} />
-                        <div className={styles.linkName}>
-                            <div>{adjacentEvents?.previousEvent?.title}</div>
-                            <div className={styles.date}>
-                                {formatDate(adjacentEvents?.previousEvent?.date?.date, 'D MMMM YYYY')}
+                <section className={styles.footerLinks}>
+                    {adjacentEvents?.previousEvent && (
+                        <Link
+                            href={`/stargazing/${adjacentEvents?.previousEvent?.id}`}
+                            title={adjacentEvents?.previousEvent?.title}
+                        >
+                            <Icon name={'KeyboardLeft'} />
+                            <div className={styles.linkName}>
+                                <div>{adjacentEvents?.previousEvent?.title}</div>
+                                <div className={styles.date}>
+                                    {formatDate(adjacentEvents?.previousEvent?.date?.date, 'D MMMM YYYY')}
+                                </div>
                             </div>
-                        </div>
-                    </Link>
-                )}
+                        </Link>
+                    )}
 
-                {adjacentEvents?.nextEvent && (
-                    <Link
-                        href={`/stargazing/${adjacentEvents?.nextEvent?.id}`}
-                        title={adjacentEvents?.nextEvent?.title}
-                    >
-                        <div className={styles.linkName}>
-                            <div>{adjacentEvents?.nextEvent?.title}</div>
-                            <div className={styles.date}>
-                                {formatDate(adjacentEvents?.nextEvent?.date?.date, 'D MMMM YYYY')}
+                    {adjacentEvents?.nextEvent && (
+                        <Link
+                            href={`/stargazing/${adjacentEvents?.nextEvent?.id}`}
+                            title={adjacentEvents?.nextEvent?.title}
+                        >
+                            <div className={styles.linkName}>
+                                <div>{adjacentEvents?.nextEvent?.title}</div>
+                                <div className={styles.date}>
+                                    {formatDate(adjacentEvents?.nextEvent?.date?.date, 'D MMMM YYYY')}
+                                </div>
                             </div>
-                        </div>
-                        <Icon name={'KeyboardRight'} />
-                    </Link>
-                )}
-            </section>
+                            <Icon name={'KeyboardRight'} />
+                        </Link>
+                    )}
+                </section>
 
-            <AppFooter />
-        </AppLayout>
+                <AppFooter />
+            </AppLayout>
+        </>
     )
 }
 

--- a/client/pages/stargazing/faq.tsx
+++ b/client/pages/stargazing/faq.tsx
@@ -2,6 +2,7 @@ import React from 'react'
 import { Container } from 'simple-react-ui-kit'
 
 import { GetStaticPropsContext, GetStaticPropsResult, NextPage } from 'next'
+import Head from 'next/head'
 import Link from 'next/link'
 import { useTranslation } from 'next-i18next/pages'
 import { serverSideTranslations } from 'next-i18next/pages/serverSideTranslations'
@@ -14,264 +15,430 @@ const StargazingFAQPage: NextPage<object> = () => {
 
     const title = t('pages.stargazing-faq.title', 'Часто задаваемые вопросы')
 
-    return (
-        <AppLayout
-            canonical={'stargazing/faq'}
-            title={title}
-            description={t(
-                'pages.stargazing-faq.description',
-                'Узнайте ответы на частые вопросы об астровыездах: регистрация, что взять с собой, стоимость, длительность и как добраться. Готовьтесь к ночи под звездами с комфортом!'
-            )}
-        >
-            <AppToolbar
-                title={title}
-                currentPage={title}
-                links={[
-                    {
-                        link: '/stargazing',
-                        text: t('menu.stargazing', 'Астровыезды')
-                    }
-                ]}
-            />
+    const faqJsonLdItems = [
+        {
+            q: t('pages.stargazing-faq.questions.where.question', '❓Как узнать, где проходит?'),
+            a: t(
+                'pages.stargazing-faq.questions.where.answer',
+                'Наши астровыезды всегда проходят за городом. Обычно в пределах 40-70 км. Мы уезжаем от засветки и городских огней, чтобы увидеть звёзды. Точная локация доступна вам после регистрации. Если вдруг вы потеряли место локации - вернитесь на страницу регистрации снова по той же ссылке. Там есть геолокация - Яндекс.Карта и Google.Карта.'
+            )
+        },
+        {
+            q: t('pages.stargazing-faq.questions.registration.question', '❓Можно ли приехать без регистрации?'),
+            a: t(
+                'pages.stargazing-faq.questions.registration.answer',
+                'Нет, нельзя. Регистрация обязательна, так как она позволяет нам планировать мероприятие, уведомлять участников о возможных изменениях и обеспечивать комфорт для всех.'
+            )
+        },
+        {
+            q: t('pages.stargazing-faq.questions.qr.question', '❓Зачем нужен QR-код?'),
+            a: t(
+                'pages.stargazing-faq.questions.qr.answer',
+                'QR-код – это ваш входной билет на наше мероприятие. Его будут проверять на въезде. Просим приготовить заранее, чтобы не создавать пробок на месте. Если у вас нет QR-кода – мы вынуждены вам отказать. QR-код – это наш способ регулировать количество участников астровыезда на площадке. Наш природный ланшафт, да и физические возможности команды имеют границы. Просим уважать это и отнестись с пониманием.'
+            )
+        },
+        {
+            q: t('pages.stargazing-faq.questions.what-to-bring.question', '❓Что брать с собой?'),
+            a: t(
+                'pages.stargazing-faq.questions.what-to-bring.answer',
+                'Для комфортного пребывания на астроплощадке обязательно иметь с собой теплую одежду (мы в степи, ночью там ветер и холодно), туристический коврик, походные стулья, пледы. Рекомендуем также - термосы с чаем/кофе и бутерброды. Советуем взять репеллент от насекомых. Кальяны, шашлыки, алкоголь, сигареты – под запретом! А еще у нас самая чистая площадка. После астровыезда не находим ни одного фантика и бумажки и очень благодарим вас за это!'
+            )
+        },
+        {
+            q: t('pages.stargazing-faq.questions.no-car.question', '❓У меня нет машины, что делать?'),
+            a: `${t('pages.stargazing-faq.questions.no-car.answer', 'Мы не организуем транспорт и не занимаемся перевозками. Наша задача – организовать крутое мероприятие, а ваша – на него приехать. Но для вашего удобства мы создали чат')} ${t('pages.stargazing-faq.questions.no-car.poputchiki', 'Астро.Попутчики')}${t('pages.stargazing-faq.questions.no-car.answer2', '. Добавляйтесь, знакомьтесь и находите компанию. Там все классные, контактные, обязательные. Хотите общение на космические темы? Добавляйтесь в тематический')} ${t('pages.stargazing-faq.questions.no-car.chat', 'Астро.Чат')}!`
+        },
+        {
+            q: t(
+                'pages.stargazing-faq.questions.public-transport.question',
+                '❓Можно ли добраться до места проведения астровыезда на общественном транспорте?'
+            ),
+            a: t(
+                'pages.stargazing-faq.questions.public-transport.answer',
+                'К сожалению, нет. Место проведения находится вдали от маршрутов общественного транспорта. Вы можете добраться туда на собственном автомобиле или присоединиться к другим участникам, если они готовы взять вас с собой. Мы рекомендуем договориться об этом заранее через наш Telegram-канал.'
+            )
+        },
+        {
+            q: t('pages.stargazing-faq.questions.start-time.question', '❓Во сколько начало?'),
+            a: t(
+                'pages.stargazing-faq.questions.start-time.answer',
+                'В каждом анонсе астровыезда есть конкретное время начала. В этот раз это 21.30. Сбор гостей на площадке объявлен с 20.00 до 21.00. Это означает, что мы просим вас приехать к нам заранее – послушать музыку, сфотографироваться с Луной и в подсолнухах, посмотреть на закаты, надышаться степью. И что важно, припарковать автомобиль и не создавать пробок. Мы очень это ценим!'
+            )
+        },
+        {
+            q: t('pages.stargazing-faq.questions.price.question', '❓Сколько стоит?'),
+            a: `${t('pages.stargazing-faq.questions.price.answer', 'Все наши астровыезды бесплатны. Проект растет и развивается и мы всегда рады поддержке от слушателей и подписчиков. Для этого есть')} ${t('pages.stargazing-faq.questions.price.donates', 'ДОНАТЫ')}${t('pages.stargazing-faq.questions.price.answer2', '. Хотите нас поддержать – мы будем вам признательны!')}`
+        },
+        {
+            q: t('pages.stargazing-faq.questions.duration.question', '❓Сколько длится астровыезд?'),
+            a: t(
+                'pages.stargazing-faq.questions.duration.answer',
+                'В среднем официальная программа от начала лекции - до наблюдений в телескопы длится 2 часа. Но для вас они пролетят незаметно, гарантируем. А дальше вы сами выбираете – оставаться ли смотреть на небо с телескопами, или возвращаться домой. примерное время окончания: 00:30.'
+            )
+        },
+        {
+            q: t('pages.stargazing-faq.questions.weather.question', '❓Что делать, если будет облачно или дождь?'),
+            a: t(
+                'pages.stargazing-faq.questions.weather.answer',
+                'Если прогноз погоды неблагоприятный (облака или осадки), мероприятие может быть отменено или перенесено. Мы всегда предупреждаем участников о таких изменениях через наш Telegram-канал, поэтому обязательно следите за обновлениями.'
+            )
+        },
+        {
+            q: t('pages.stargazing-faq.questions.telescopes.question', '❓Нужно ли приносить собственный телескоп?'),
+            a: t(
+                'pages.stargazing-faq.questions.telescopes.answer',
+                'Нет, приносить телескоп не обязательно. У нас всегда есть несколько телескопов для общего пользования. Если у вас есть свой инструмент, вы можете взять его, и наши эксперты помогут вам с настройкой и использованием.'
+            )
+        },
+        {
+            q: t('pages.stargazing-faq.questions.kids.question', '❓Можно ли детям?'),
+            a: t(
+                'pages.stargazing-faq.questions.kids.answer',
+                'Можно и нужно! Очень рады, когда подрастающее поколение интересуется наукой! Но есть рекомендованный возраст – от 6 лет. Поверьте нашему опыту.'
+            )
+        },
+        {
+            q: t('pages.stargazing-faq.questions.photo.question', '❓Можно ли фотографировать?'),
+            a: t(
+                'pages.stargazing-faq.questions.photo.answer',
+                'Конечно! Вы можете делать фотографии, но просьба соблюдать правила этикета, чтобы не мешать другим участникам. Не используйте яркие вспышки или фонари, так как это может испортить ночное наблюдение.'
+            )
+        },
+        {
+            q: t('pages.stargazing-faq.questions.merch.question', '❓Как и где купить ваш мерч?'),
+            a: t(
+                'pages.stargazing-faq.questions.merch.answer',
+                'На астрополяну везем худи, футболки, автонаклейки, открытки и стикерпаки. Хотите поддержать проект - купите наш мерч!'
+            )
+        },
+        {
+            q: t(
+                'pages.stargazing-faq.questions.cancel.question',
+                '❓Я зарегистрировался и не могу поехать. Что делать?'
+            ),
+            a: t(
+                'pages.stargazing-faq.questions.cancel.answer',
+                'Просто отмените бронирование по прежней ссылке. На сайте появятся свободные слоты и люди смогут зарегистрироваться.'
+            )
+        },
+        {
+            q: t(
+                'pages.stargazing-faq.questions.more-people.question',
+                '❓Я зарегистрировал 1\\2\\3\\4\\5 человек, а можно ли взять больше?'
+            ),
+            a: t(
+                'pages.stargazing-faq.questions.more-people.answer',
+                'Нет, нельзя. Наши правила едины для всех. По QR-коду на площадку проезжает то количество людей, которое вы зарегистрировали. Никак иначе.'
+            )
+        },
+        {
+            q: t(
+                'pages.stargazing-faq.questions.late-registration.question',
+                '❓Регистрация закончилась и я не успел (а). Можно я приеду? Пожалуйста!'
+            ),
+            a: t(
+                'pages.stargazing-faq.questions.late-registration.answer',
+                'Нет, увы. Наши правила едины для всех. Мы не зря ввели систему регистраций и следим за въездом на астроплощадку.'
+            )
+        },
+        {
+            q: t('pages.stargazing-faq.questions.support.question', '❓Вы мне нравитесь! Как вас поддержать?'),
+            a: `${t('pages.stargazing-faq.questions.support.answer', 'У нас есть')} ${t('pages.stargazing-faq.questions.support.donates', 'донаты')}${t('pages.stargazing-faq.questions.support.answer2', '. Мы постоянно докупаем оборудование, обновляем технические возможности, создаем мерч и всякие активности. Ваша поддержка - это ❤︎❤︎❤︎')}`
+        },
+        {
+            q: t('pages.stargazing-faq.questions.feedback.question', '❓Где написать про вас отзыв?'),
+            a: t(
+                'pages.stargazing-faq.questions.feedback.answer',
+                'Во всех социальных сетях наша группа называется "Смотри на звёзды". Мы ценим обратную связь и всегда читаем ваши отзывы. Спасибо вам за них!'
+            )
+        }
+    ]
 
-            <div>
-                {t(
+    const faqJsonLd = {
+        '@context': 'https://schema.org',
+        '@type': 'FAQPage',
+        mainEntity: faqJsonLdItems.map(({ q, a }) => ({
+            '@type': 'Question',
+            name: q,
+            acceptedAnswer: {
+                '@type': 'Answer',
+                text: a
+            }
+        }))
+    }
+
+    return (
+        <>
+            <Head>
+                <script
+                    type={'application/ld+json'}
+                    dangerouslySetInnerHTML={{ __html: JSON.stringify(faqJsonLd) }}
+                />
+            </Head>
+            <AppLayout
+                canonical={'stargazing/faq'}
+                title={title}
+                description={t(
                     'pages.stargazing-faq.description',
                     'Узнайте ответы на частые вопросы об астровыездах: регистрация, что взять с собой, стоимость, длительность и как добраться. Готовьтесь к ночи под звездами с комфортом!'
                 )}
-                <Link
-                    href={'https://t.me/look_at_stars'}
-                    style={{ marginLeft: '5px' }}
-                    title={t('common.telegram', 'Телеграм')}
-                    rel={'noindex nofollow'}
-                    target={'_blank'}
-                >
-                    {t('common.look-at-the-stars', 'Смотри на звёзды')}
-                </Link>
-                {'.'}
-            </div>
+            >
+                <AppToolbar
+                    title={title}
+                    currentPage={title}
+                    links={[
+                        {
+                            link: '/stargazing',
+                            text: t('menu.stargazing', 'Астровыезды')
+                        }
+                    ]}
+                />
 
-            {[
-                {
-                    question: t('pages.stargazing-faq.questions.where.question', '❓Как узнать, где проходит?'),
-                    answer: t(
-                        'pages.stargazing-faq.questions.where.answer',
-                        'Наши астровыезды всегда проходят за городом. Обычно в пределах 40-70 км. Мы уезжаем от засветки и городских огней, чтобы увидеть звёзды. Точная локация доступна вам после регистрации. Если вдруг вы потеряли место локации - вернитесь на страницу регистрации снова по той же ссылке. Там есть геолокация - Яндекс.Карта и Google.Карта.'
-                    )
-                },
-                {
-                    question: t(
-                        'pages.stargazing-faq.questions.registration.question',
-                        '❓Можно ли приехать без регистрации?'
-                    ),
-                    answer: t(
-                        'pages.stargazing-faq.questions.registration.answer',
-                        'Нет, нельзя. Регистрация обязательна, так как она позволяет нам планировать мероприятие, уведомлять участников о возможных изменениях и обеспечивать комфорт для всех.'
-                    )
-                },
-                {
-                    question: t('pages.stargazing-faq.questions.qr.question', '❓Зачем нужен QR-код?'),
-                    answer: t(
-                        'pages.stargazing-faq.questions.qr.answer',
-                        'QR-код – это ваш входной билет на наше мероприятие. Его будут проверять на въезде. Просим приготовить заранее, чтобы не создавать пробок на месте. Если у вас нет QR-кода – мы вынуждены вам отказать. QR-код – это наш способ регулировать количество участников астровыезда на площадке. Наш природный ланшафт, да и физические возможности команды имеют границы. Просим уважать это и отнестись с пониманием.'
-                    )
-                },
-                {
-                    question: t('pages.stargazing-faq.questions.what-to-bring.question', '❓Что брать с собой?'),
-                    answer: t(
-                        'pages.stargazing-faq.questions.what-to-bring.answer',
-                        'Для комфортного пребывания на астроплощадке обязательно иметь с собой теплую одежду (мы в степи, ночью там ветер и холодно), туристический коврик, походные стулья, пледы. Рекомендуем также - термосы с чаем/кофе и бутерброды. Советуем взять репеллент от насекомых. Кальяны, шашлыки, алкоголь, сигареты – под запретом! А еще у нас самая чистая площадка. После астровыезда не находим ни одного фантика и бумажки и очень благодарим вас за это!'
-                    )
-                },
-                {
-                    question: t('pages.stargazing-faq.questions.no-car.question', '❓У меня нет машины, что делать?'),
-                    answer: (
-                        <>
-                            {t(
-                                'pages.stargazing-faq.questions.no-car.answer',
-                                'Мы не организуем транспорт и не занимаемся перевозками. Наша задача – организовать крутое мероприятие, а ваша – на него приехать. Но для вашего удобства мы создали чат'
-                            )}{' '}
-                            <a
-                                href='https://t.me/stargazing_oren'
-                                rel='nofollow noopener'
-                                target={'_blank'}
-                                title={t('pages.stargazing-faq.questions.no-car.poputchiki', 'Астро.Попутчики')}
-                            >
-                                {t('pages.stargazing-faq.questions.no-car.poputchiki', 'Астро.Попутчики')}
-                            </a>
-                            {t(
-                                'pages.stargazing-faq.questions.no-car.answer2',
-                                '. Добавляйтесь, знакомьтесь и находите компанию. Там все классные, контактные, обязательные. Хотите общение на космические темы? Добавляйтесь в тематический'
-                            )}{' '}
-                            <a
-                                href='https://t.me/all_astronomers'
-                                rel='nofollow noopener'
-                                target={'_blank'}
-                                title={t('pages.stargazing-faq.questions.no-car.chat', 'Астро.Чат')}
-                            >
-                                {t('pages.stargazing-faq.questions.no-car.chat', 'Астро.Чат')}
-                            </a>
-                            {'!'}
-                        </>
-                    )
-                },
-                {
-                    question: t(
-                        'pages.stargazing-faq.questions.public-transport.question',
-                        '❓Можно ли добраться до места проведения астровыезда на общественном транспорте?'
-                    ),
-                    answer: t(
-                        'pages.stargazing-faq.questions.public-transport.answer',
-                        'К сожалению, нет. Место проведения находится вдали от маршрутов общественного транспорта. Вы можете добраться туда на собственном автомобиле или присоединиться к другим участникам, если они готовы взять вас с собой. Мы рекомендуем договориться об этом заранее через наш Telegram-канал.'
-                    )
-                },
-                {
-                    question: t('pages.stargazing-faq.questions.start-time.question', '❓Во сколько начало?'),
-                    answer: t(
-                        'pages.stargazing-faq.questions.start-time.answer',
-                        'В каждом анонсе астровыезда есть конкретное время начала. В этот раз это 21.30. Сбор гостей на площадке объявлен с 20.00 до 21.00. Это означает, что мы просим вас приехать к нам заранее – послушать музыку, сфотографироваться с Луной и в подсолнухах, посмотреть на закаты, надышаться степью. И что важно, припарковать автомобиль и не создавать пробок. Мы очень это ценим!'
-                    )
-                },
-                {
-                    question: t('pages.stargazing-faq.questions.price.question', '❓Сколько стоит?'),
-                    answer: (
-                        <>
-                            {t(
-                                'pages.stargazing-faq.questions.price.answer',
-                                'Все наши астровыезды бесплатны. Проект растет и развивается и мы всегда рады поддержке от слушателей и подписчиков. Для этого есть'
-                            )}{' '}
-                            <a
-                                href='https://pay.cloudtips.ru/p/6818d70d'
-                                rel='nofollow noopener'
-                                target={'_blank'}
-                                title={t('pages.stargazing-faq.questions.price.donates', 'ДОНАТЫ')}
-                            >
-                                {t('pages.stargazing-faq.questions.price.donates', 'ДОНАТЫ')}
-                            </a>
-                            {t(
-                                'pages.stargazing-faq.questions.price.answer2',
-                                '. Хотите нас поддержать – мы будем вам признательны!'
-                            )}
-                        </>
-                    )
-                },
-                {
-                    question: t('pages.stargazing-faq.questions.duration.question', '❓Сколько длится астровыезд?'),
-                    answer: t(
-                        'pages.stargazing-faq.questions.duration.answer',
-                        'В среднем официальная программа от начала лекции - до наблюдений в телескопы длится 2 часа. Но для вас они пролетят незаметно, гарантируем. А дальше вы сами выбираете – оставаться ли смотреть на небо с телескопами, или возвращаться домой. примерное время окончания: 00:30.'
-                    )
-                },
-                {
-                    question: t(
-                        'pages.stargazing-faq.questions.weather.question',
-                        '❓Что делать, если будет облачно или дождь?'
-                    ),
-                    answer: t(
-                        'pages.stargazing-faq.questions.weather.answer',
-                        'Если прогноз погоды неблагоприятный (облака или осадки), мероприятие может быть отменено или перенесено. Мы всегда предупреждаем участников о таких изменениях через наш Telegram-канал, поэтому обязательно следите за обновлениями.'
-                    )
-                },
-                {
-                    question: t(
-                        'pages.stargazing-faq.questions.telescopes.question',
-                        '❓Нужно ли приносить собственный телескоп?'
-                    ),
-                    answer: t(
-                        'pages.stargazing-faq.questions.telescopes.answer',
-                        'Нет, приносить телескоп не обязательно. У нас всегда есть несколько телескопов для общего пользования. Если у вас есть свой инструмент, вы можете взять его, и наши эксперты помогут вам с настройкой и использованием.'
-                    )
-                },
-                {
-                    question: t('pages.stargazing-faq.questions.kids.question', '❓Можно ли детям?'),
-                    answer: t(
-                        'pages.stargazing-faq.questions.kids.answer',
-                        'Можно и нужно! Очень рады, когда подрастающее поколение интересуется наукой! Но есть рекомендованный возраст – от 6 лет. Поверьте нашему опыту.'
-                    )
-                },
-                {
-                    question: t('pages.stargazing-faq.questions.photo.question', '❓Можно ли фотографировать?'),
-                    answer: t(
-                        'pages.stargazing-faq.questions.photo.answer',
-                        'Конечно! Вы можете делать фотографии, но просьба соблюдать правила этикета, чтобы не мешать другим участникам. Не используйте яркие вспышки или фонари, так как это может испортить ночное наблюдение.'
-                    )
-                },
-                {
-                    question: t('pages.stargazing-faq.questions.merch.question', '❓Как и где купить ваш мерч?'),
-                    answer: t(
-                        'pages.stargazing-faq.questions.merch.answer',
-                        'На астрополяну везем худи, футболки, автонаклейки, открытки и стикерпаки. Хотите поддержать проект - купите наш мерч!'
-                    )
-                },
-                {
-                    question: t(
-                        'pages.stargazing-faq.questions.cancel.question',
-                        '❓Я зарегистрировался и не могу поехать. Что делать?'
-                    ),
-                    answer: t(
-                        'pages.stargazing-faq.questions.cancel.answer',
-                        'Просто отмените бронирование по прежней ссылке. На сайте появятся свободные слоты и люди смогут зарегистрироваться.'
-                    )
-                },
-                {
-                    question: t(
-                        'pages.stargazing-faq.questions.more-people.question',
-                        '❓Я зарегистрировал 1\\2\\3\\4\\5 человек, а можно ли взять больше?'
-                    ),
-                    answer: t(
-                        'pages.stargazing-faq.questions.more-people.answer',
-                        'Нет, нельзя. Наши правила едины для всех. По QR-коду на площадку проезжает то количество людей, которое вы зарегистрировали. Никак иначе.'
-                    )
-                },
-                {
-                    question: t(
-                        'pages.stargazing-faq.questions.late-registration.question',
-                        '❓Регистрация закончилась и я не успел (а). Можно я приеду? Пожалуйста!'
-                    ),
-                    answer: t(
-                        'pages.stargazing-faq.questions.late-registration.answer',
-                        'Нет, увы. Наши правила едины для всех. Мы не зря ввели систему регистраций и следим за въездом на астроплощадку.'
-                    )
-                },
-                {
-                    question: t(
-                        'pages.stargazing-faq.questions.support.question',
-                        '❓Вы мне нравитесь! Как вас поддержать?'
-                    ),
-                    answer: (
-                        <>
-                            {t('pages.stargazing-faq.questions.support.answer', 'У нас есть')}{' '}
-                            <a
-                                href='https://pay.cloudtips.ru/p/6818d70d'
-                                rel='nofollow noopener'
-                                target={'_blank'}
-                                title={t('pages.stargazing-faq.questions.support.donates', 'ДОНАТЫ')}
-                            >
-                                {t('pages.stargazing-faq.questions.support.donates', 'донаты')}
-                            </a>
-                            {t(
-                                'pages.stargazing-faq.questions.support.answer2',
-                                '. Мы постоянно докупаем оборудование, обновляем технические возможности, создаем мерч и всякие активности. Ваша поддержка - это ❤︎❤︎❤︎'
-                            )}
-                        </>
-                    )
-                },
-                {
-                    question: t('pages.stargazing-faq.questions.feedback.question', '❓Где написать про вас отзыв?'),
-                    answer: t(
-                        'pages.stargazing-faq.questions.feedback.answer',
-                        'Во всех социальных сетях наша группа называется "Смотри на звёзды". Мы ценим обратную связь и всегда читаем ваши отзывы. Спасибо вам за них!'
-                    )
-                }
-            ].map((item, idx) => (
-                <div key={idx}>
-                    <h3 style={{ marginBottom: 5, fontSize: '18px' }}>{item.question}</h3>
-                    <Container>{item.answer}</Container>
+                <div>
+                    {t(
+                        'pages.stargazing-faq.description',
+                        'Узнайте ответы на частые вопросы об астровыездах: регистрация, что взять с собой, стоимость, длительность и как добраться. Готовьтесь к ночи под звездами с комфортом!'
+                    )}
+                    <Link
+                        href={'https://t.me/look_at_stars'}
+                        style={{ marginLeft: '5px' }}
+                        title={t('common.telegram', 'Телеграм')}
+                        rel={'noindex nofollow'}
+                        target={'_blank'}
+                    >
+                        {t('common.look-at-the-stars', 'Смотри на звёзды')}
+                    </Link>
+                    {'.'}
                 </div>
-            ))}
 
-            <AppFooter />
-        </AppLayout>
+                {[
+                    {
+                        question: t('pages.stargazing-faq.questions.where.question', '❓Как узнать, где проходит?'),
+                        answer: t(
+                            'pages.stargazing-faq.questions.where.answer',
+                            'Наши астровыезды всегда проходят за городом. Обычно в пределах 40-70 км. Мы уезжаем от засветки и городских огней, чтобы увидеть звёзды. Точная локация доступна вам после регистрации. Если вдруг вы потеряли место локации - вернитесь на страницу регистрации снова по той же ссылке. Там есть геолокация - Яндекс.Карта и Google.Карта.'
+                        )
+                    },
+                    {
+                        question: t(
+                            'pages.stargazing-faq.questions.registration.question',
+                            '❓Можно ли приехать без регистрации?'
+                        ),
+                        answer: t(
+                            'pages.stargazing-faq.questions.registration.answer',
+                            'Нет, нельзя. Регистрация обязательна, так как она позволяет нам планировать мероприятие, уведомлять участников о возможных изменениях и обеспечивать комфорт для всех.'
+                        )
+                    },
+                    {
+                        question: t('pages.stargazing-faq.questions.qr.question', '❓Зачем нужен QR-код?'),
+                        answer: t(
+                            'pages.stargazing-faq.questions.qr.answer',
+                            'QR-код – это ваш входной билет на наше мероприятие. Его будут проверять на въезде. Просим приготовить заранее, чтобы не создавать пробок на месте. Если у вас нет QR-кода – мы вынуждены вам отказать. QR-код – это наш способ регулировать количество участников астровыезда на площадке. Наш природный ланшафт, да и физические возможности команды имеют границы. Просим уважать это и отнестись с пониманием.'
+                        )
+                    },
+                    {
+                        question: t('pages.stargazing-faq.questions.what-to-bring.question', '❓Что брать с собой?'),
+                        answer: t(
+                            'pages.stargazing-faq.questions.what-to-bring.answer',
+                            'Для комфортного пребывания на астроплощадке обязательно иметь с собой теплую одежду (мы в степи, ночью там ветер и холодно), туристический коврик, походные стулья, пледы. Рекомендуем также - термосы с чаем/кофе и бутерброды. Советуем взять репеллент от насекомых. Кальяны, шашлыки, алкоголь, сигареты – под запретом! А еще у нас самая чистая площадка. После астровыезда не находим ни одного фантика и бумажки и очень благодарим вас за это!'
+                        )
+                    },
+                    {
+                        question: t(
+                            'pages.stargazing-faq.questions.no-car.question',
+                            '❓У меня нет машины, что делать?'
+                        ),
+                        answer: (
+                            <>
+                                {t(
+                                    'pages.stargazing-faq.questions.no-car.answer',
+                                    'Мы не организуем транспорт и не занимаемся перевозками. Наша задача – организовать крутое мероприятие, а ваша – на него приехать. Но для вашего удобства мы создали чат'
+                                )}{' '}
+                                <a
+                                    href='https://t.me/stargazing_oren'
+                                    rel='nofollow noopener'
+                                    target={'_blank'}
+                                    title={t('pages.stargazing-faq.questions.no-car.poputchiki', 'Астро.Попутчики')}
+                                >
+                                    {t('pages.stargazing-faq.questions.no-car.poputchiki', 'Астро.Попутчики')}
+                                </a>
+                                {t(
+                                    'pages.stargazing-faq.questions.no-car.answer2',
+                                    '. Добавляйтесь, знакомьтесь и находите компанию. Там все классные, контактные, обязательные. Хотите общение на космические темы? Добавляйтесь в тематический'
+                                )}{' '}
+                                <a
+                                    href='https://t.me/all_astronomers'
+                                    rel='nofollow noopener'
+                                    target={'_blank'}
+                                    title={t('pages.stargazing-faq.questions.no-car.chat', 'Астро.Чат')}
+                                >
+                                    {t('pages.stargazing-faq.questions.no-car.chat', 'Астро.Чат')}
+                                </a>
+                                {'!'}
+                            </>
+                        )
+                    },
+                    {
+                        question: t(
+                            'pages.stargazing-faq.questions.public-transport.question',
+                            '❓Можно ли добраться до места проведения астровыезда на общественном транспорте?'
+                        ),
+                        answer: t(
+                            'pages.stargazing-faq.questions.public-transport.answer',
+                            'К сожалению, нет. Место проведения находится вдали от маршрутов общественного транспорта. Вы можете добраться туда на собственном автомобиле или присоединиться к другим участникам, если они готовы взять вас с собой. Мы рекомендуем договориться об этом заранее через наш Telegram-канал.'
+                        )
+                    },
+                    {
+                        question: t('pages.stargazing-faq.questions.start-time.question', '❓Во сколько начало?'),
+                        answer: t(
+                            'pages.stargazing-faq.questions.start-time.answer',
+                            'В каждом анонсе астровыезда есть конкретное время начала. В этот раз это 21.30. Сбор гостей на площадке объявлен с 20.00 до 21.00. Это означает, что мы просим вас приехать к нам заранее – послушать музыку, сфотографироваться с Луной и в подсолнухах, посмотреть на закаты, надышаться степью. И что важно, припарковать автомобиль и не создавать пробок. Мы очень это ценим!'
+                        )
+                    },
+                    {
+                        question: t('pages.stargazing-faq.questions.price.question', '❓Сколько стоит?'),
+                        answer: (
+                            <>
+                                {t(
+                                    'pages.stargazing-faq.questions.price.answer',
+                                    'Все наши астровыезды бесплатны. Проект растет и развивается и мы всегда рады поддержке от слушателей и подписчиков. Для этого есть'
+                                )}{' '}
+                                <a
+                                    href='https://pay.cloudtips.ru/p/6818d70d'
+                                    rel='nofollow noopener'
+                                    target={'_blank'}
+                                    title={t('pages.stargazing-faq.questions.price.donates', 'ДОНАТЫ')}
+                                >
+                                    {t('pages.stargazing-faq.questions.price.donates', 'ДОНАТЫ')}
+                                </a>
+                                {t(
+                                    'pages.stargazing-faq.questions.price.answer2',
+                                    '. Хотите нас поддержать – мы будем вам признательны!'
+                                )}
+                            </>
+                        )
+                    },
+                    {
+                        question: t('pages.stargazing-faq.questions.duration.question', '❓Сколько длится астровыезд?'),
+                        answer: t(
+                            'pages.stargazing-faq.questions.duration.answer',
+                            'В среднем официальная программа от начала лекции - до наблюдений в телескопы длится 2 часа. Но для вас они пролетят незаметно, гарантируем. А дальше вы сами выбираете – оставаться ли смотреть на небо с телескопами, или возвращаться домой. примерное время окончания: 00:30.'
+                        )
+                    },
+                    {
+                        question: t(
+                            'pages.stargazing-faq.questions.weather.question',
+                            '❓Что делать, если будет облачно или дождь?'
+                        ),
+                        answer: t(
+                            'pages.stargazing-faq.questions.weather.answer',
+                            'Если прогноз погоды неблагоприятный (облака или осадки), мероприятие может быть отменено или перенесено. Мы всегда предупреждаем участников о таких изменениях через наш Telegram-канал, поэтому обязательно следите за обновлениями.'
+                        )
+                    },
+                    {
+                        question: t(
+                            'pages.stargazing-faq.questions.telescopes.question',
+                            '❓Нужно ли приносить собственный телескоп?'
+                        ),
+                        answer: t(
+                            'pages.stargazing-faq.questions.telescopes.answer',
+                            'Нет, приносить телескоп не обязательно. У нас всегда есть несколько телескопов для общего пользования. Если у вас есть свой инструмент, вы можете взять его, и наши эксперты помогут вам с настройкой и использованием.'
+                        )
+                    },
+                    {
+                        question: t('pages.stargazing-faq.questions.kids.question', '❓Можно ли детям?'),
+                        answer: t(
+                            'pages.stargazing-faq.questions.kids.answer',
+                            'Можно и нужно! Очень рады, когда подрастающее поколение интересуется наукой! Но есть рекомендованный возраст – от 6 лет. Поверьте нашему опыту.'
+                        )
+                    },
+                    {
+                        question: t('pages.stargazing-faq.questions.photo.question', '❓Можно ли фотографировать?'),
+                        answer: t(
+                            'pages.stargazing-faq.questions.photo.answer',
+                            'Конечно! Вы можете делать фотографии, но просьба соблюдать правила этикета, чтобы не мешать другим участникам. Не используйте яркие вспышки или фонари, так как это может испортить ночное наблюдение.'
+                        )
+                    },
+                    {
+                        question: t('pages.stargazing-faq.questions.merch.question', '❓Как и где купить ваш мерч?'),
+                        answer: t(
+                            'pages.stargazing-faq.questions.merch.answer',
+                            'На астрополяну везем худи, футболки, автонаклейки, открытки и стикерпаки. Хотите поддержать проект - купите наш мерч!'
+                        )
+                    },
+                    {
+                        question: t(
+                            'pages.stargazing-faq.questions.cancel.question',
+                            '❓Я зарегистрировался и не могу поехать. Что делать?'
+                        ),
+                        answer: t(
+                            'pages.stargazing-faq.questions.cancel.answer',
+                            'Просто отмените бронирование по прежней ссылке. На сайте появятся свободные слоты и люди смогут зарегистрироваться.'
+                        )
+                    },
+                    {
+                        question: t(
+                            'pages.stargazing-faq.questions.more-people.question',
+                            '❓Я зарегистрировал 1\\2\\3\\4\\5 человек, а можно ли взять больше?'
+                        ),
+                        answer: t(
+                            'pages.stargazing-faq.questions.more-people.answer',
+                            'Нет, нельзя. Наши правила едины для всех. По QR-коду на площадку проезжает то количество людей, которое вы зарегистрировали. Никак иначе.'
+                        )
+                    },
+                    {
+                        question: t(
+                            'pages.stargazing-faq.questions.late-registration.question',
+                            '❓Регистрация закончилась и я не успел (а). Можно я приеду? Пожалуйста!'
+                        ),
+                        answer: t(
+                            'pages.stargazing-faq.questions.late-registration.answer',
+                            'Нет, увы. Наши правила едины для всех. Мы не зря ввели систему регистраций и следим за въездом на астроплощадку.'
+                        )
+                    },
+                    {
+                        question: t(
+                            'pages.stargazing-faq.questions.support.question',
+                            '❓Вы мне нравитесь! Как вас поддержать?'
+                        ),
+                        answer: (
+                            <>
+                                {t('pages.stargazing-faq.questions.support.answer', 'У нас есть')}{' '}
+                                <a
+                                    href='https://pay.cloudtips.ru/p/6818d70d'
+                                    rel='nofollow noopener'
+                                    target={'_blank'}
+                                    title={t('pages.stargazing-faq.questions.support.donates', 'ДОНАТЫ')}
+                                >
+                                    {t('pages.stargazing-faq.questions.support.donates', 'донаты')}
+                                </a>
+                                {t(
+                                    'pages.stargazing-faq.questions.support.answer2',
+                                    '. Мы постоянно докупаем оборудование, обновляем технические возможности, создаем мерч и всякие активности. Ваша поддержка - это ❤︎❤︎❤︎'
+                                )}
+                            </>
+                        )
+                    },
+                    {
+                        question: t(
+                            'pages.stargazing-faq.questions.feedback.question',
+                            '❓Где написать про вас отзыв?'
+                        ),
+                        answer: t(
+                            'pages.stargazing-faq.questions.feedback.answer',
+                            'Во всех социальных сетях наша группа называется "Смотри на звёзды". Мы ценим обратную связь и всегда читаем ваши отзывы. Спасибо вам за них!'
+                        )
+                    }
+                ].map((item, idx) => (
+                    <div key={idx}>
+                        <h3 style={{ marginBottom: 5, fontSize: '18px' }}>{item.question}</h3>
+                        <Container>{item.answer}</Container>
+                    </div>
+                ))}
+
+                <AppFooter />
+            </AppLayout>
+        </>
     )
 }
 

--- a/client/public/robots.txt
+++ b/client/public/robots.txt
@@ -13,6 +13,20 @@ Disallow: /mailing
 Disallow: /mailing/form
 Disallow: /users
 Disallow: /api/
+Disallow: /en/photos/form
+Disallow: /en/objects/form
+Disallow: /en/stargazing/form
+Disallow: /en/stargazing/checkin
+Disallow: /en/stargazing/entry
+Disallow: /en/mailing
+Disallow: /en/mailing/form
+Disallow: /en/users
+Disallow: /profile
+Disallow: /en/profile
+Disallow: /unsubscribe
+Disallow: /en/unsubscribe
+Disallow: /stargazing/*/statistic
+Disallow: /en/stargazing/*/statistic
 
 # Specify the main mirror of the site
 Host: https://astro.miksoft.pro

--- a/server/tests/feature/AuthGuardTest.php
+++ b/server/tests/feature/AuthGuardTest.php
@@ -61,11 +61,107 @@ final class AuthGuardTest extends CIUnitTestCase
         $this->assertArrayHasKey('messages', $json);
     }
 
+    // --- Photos endpoints (write operations) ---
+
+    public function testPatchPhotoWithoutTokenReturns401(): void
+    {
+        $result = $this->patch('photos/abc123', []);
+        $result->assertStatus(401);
+        $json = json_decode($result->getJSON(), true);
+        $this->assertArrayHasKey('messages', $json);
+    }
+
+    public function testDeletePhotoWithoutTokenReturns401(): void
+    {
+        $result = $this->delete('photos/abc123');
+        $result->assertStatus(401);
+        $json = json_decode($result->getJSON(), true);
+        $this->assertArrayHasKey('messages', $json);
+    }
+
     // --- Events endpoints ---
 
     public function testGetEventMembersWithoutTokenReturns401(): void
     {
         $result = $this->get('events/members/abc123');
+        $result->assertStatus(401);
+        $json = json_decode($result->getJSON(), true);
+        $this->assertArrayHasKey('messages', $json);
+    }
+
+    public function testPostEventsWithoutTokenReturns401(): void
+    {
+        $result = $this->post('events', []);
+        $result->assertStatus(401);
+        $json = json_decode($result->getJSON(), true);
+        $this->assertArrayHasKey('messages', $json);
+    }
+
+    public function testPatchEventWithoutTokenReturns401(): void
+    {
+        $result = $this->patch('events/abc123', []);
+        $result->assertStatus(401);
+        $json = json_decode($result->getJSON(), true);
+        $this->assertArrayHasKey('messages', $json);
+    }
+
+    public function testDeleteEventWithoutTokenReturns401(): void
+    {
+        $result = $this->delete('events/abc123');
+        $result->assertStatus(401);
+        $json = json_decode($result->getJSON(), true);
+        $this->assertArrayHasKey('messages', $json);
+    }
+
+    // --- Comments endpoints ---
+
+    public function testPostCommentsWithoutTokenReturns401(): void
+    {
+        $result = $this->post('comments', []);
+        $result->assertStatus(401);
+        $json = json_decode($result->getJSON(), true);
+        $this->assertArrayHasKey('messages', $json);
+    }
+
+    public function testDeleteCommentWithoutTokenReturns401(): void
+    {
+        $result = $this->delete('comments/abc123');
+        $result->assertStatus(401);
+        $json = json_decode($result->getJSON(), true);
+        $this->assertArrayHasKey('messages', $json);
+    }
+
+    // --- Members endpoints ---
+
+    public function testGetMembersWithoutTokenReturns401(): void
+    {
+        $result = $this->get('members');
+        $result->assertStatus(401);
+        $json = json_decode($result->getJSON(), true);
+        $this->assertArrayHasKey('messages', $json);
+    }
+
+    public function testGetMemberEventsWithoutTokenReturns401(): void
+    {
+        $result = $this->get('members/abc123/events');
+        $result->assertStatus(401);
+        $json = json_decode($result->getJSON(), true);
+        $this->assertArrayHasKey('messages', $json);
+    }
+
+    // --- Mailings write endpoints ---
+
+    public function testPostMailingsWithoutTokenReturns401(): void
+    {
+        $result = $this->post('mailings', []);
+        $result->assertStatus(401);
+        $json = json_decode($result->getJSON(), true);
+        $this->assertArrayHasKey('messages', $json);
+    }
+
+    public function testDeleteMailingWithoutTokenReturns401(): void
+    {
+        $result = $this->delete('mailings/abc123');
         $result->assertStatus(401);
         $json = json_decode($result->getJSON(), true);
         $this->assertArrayHasKey('messages', $json);

--- a/server/tests/unit/Entities/CategoryEntityTest.php
+++ b/server/tests/unit/Entities/CategoryEntityTest.php
@@ -1,0 +1,68 @@
+<?php
+
+use App\Entities\CategoryEntity;
+use CodeIgniter\Test\CIUnitTestCase;
+
+/**
+ * @internal
+ */
+final class CategoryEntityTest extends CIUnitTestCase
+{
+    // --- Cast behavior ---
+
+    public function testIdCastToInt(): void
+    {
+        $entity     = new CategoryEntity();
+        $entity->id = '5';
+        $this->assertSame(5, $entity->id);
+        $this->assertIsInt($entity->id);
+    }
+
+    public function testTitleEnCastToString(): void
+    {
+        $entity           = new CategoryEntity();
+        $entity->title_en = 'Nebulae';
+        $this->assertSame('Nebulae', $entity->title_en);
+        $this->assertIsString($entity->title_en);
+    }
+
+    public function testTitleRuCastToString(): void
+    {
+        $entity           = new CategoryEntity();
+        $entity->title_ru = 'Туманности';
+        $this->assertSame('Туманности', $entity->title_ru);
+        $this->assertIsString($entity->title_ru);
+    }
+
+    public function testDescriptionEnCastToString(): void
+    {
+        $entity                  = new CategoryEntity();
+        $entity->description_en  = 'Interstellar clouds';
+        $this->assertSame('Interstellar clouds', $entity->description_en);
+        $this->assertIsString($entity->description_en);
+    }
+
+    public function testDescriptionRuCastToString(): void
+    {
+        $entity                  = new CategoryEntity();
+        $entity->description_ru  = 'Межзвёздные облака';
+        $this->assertSame('Межзвёздные облака', $entity->description_ru);
+        $this->assertIsString($entity->description_ru);
+    }
+
+    // --- Default attribute values ---
+
+    public function testNewInstanceIdDefaultsToZero(): void
+    {
+        // 'id' cast to 'int'; CI4 Entity converts null attribute to 0 on get
+        $entity = new CategoryEntity();
+        $this->assertSame(0, $entity->id);
+    }
+
+    public function testNewInstanceTitleEnDefaultsToEmptyString(): void
+    {
+        // 'title_en' cast to 'string'; CI4 Entity converts null attribute to '' on get
+        $entity = new CategoryEntity();
+        $this->assertSame('', $entity->title_en);
+    }
+}

--- a/server/tests/unit/Entities/EventPhotoEntityTest.php
+++ b/server/tests/unit/Entities/EventPhotoEntityTest.php
@@ -1,0 +1,104 @@
+<?php
+
+use App\Entities\EventPhotoEntity;
+use CodeIgniter\Test\CIUnitTestCase;
+
+/**
+ * @internal
+ */
+final class EventPhotoEntityTest extends CIUnitTestCase
+{
+    // --- Cast behavior ---
+
+    public function testFileSizeCastToInteger(): void
+    {
+        $entity            = new EventPhotoEntity();
+        $entity->file_size = '102400';
+        $this->assertSame(102400, $entity->file_size);
+        $this->assertIsInt($entity->file_size);
+    }
+
+    public function testImageWidthCastToInteger(): void
+    {
+        $entity              = new EventPhotoEntity();
+        $entity->image_width = '1920';
+        $this->assertSame(1920, $entity->image_width);
+        $this->assertIsInt($entity->image_width);
+    }
+
+    public function testImageHeightCastToInteger(): void
+    {
+        $entity               = new EventPhotoEntity();
+        $entity->image_height = '1080';
+        $this->assertSame(1080, $entity->image_height);
+        $this->assertIsInt($entity->image_height);
+    }
+
+    // --- Datamap aliases ---
+
+    public function testEventIdDatamapAlias(): void
+    {
+        $entity          = new EventPhotoEntity();
+        $entity->eventId = 'evt-abc123';
+        $this->assertSame('evt-abc123', $entity->event_id);
+    }
+
+    public function testNameDatamapAliasWritesToFileName(): void
+    {
+        $entity       = new EventPhotoEntity();
+        $entity->name = 'dsc_0001';
+        $this->assertSame('dsc_0001', $entity->file_name);
+    }
+
+    public function testExtDatamapAliasWritesToFileExt(): void
+    {
+        $entity      = new EventPhotoEntity();
+        $entity->ext = 'jpg';
+        $this->assertSame('jpg', $entity->file_ext);
+    }
+
+    public function testWidthDatamapAliasAppliesIntCast(): void
+    {
+        $entity        = new EventPhotoEntity();
+        $entity->width = '800';
+        $this->assertSame(800, $entity->image_width);
+        $this->assertIsInt($entity->image_width);
+    }
+
+    public function testHeightDatamapAliasAppliesIntCast(): void
+    {
+        $entity         = new EventPhotoEntity();
+        $entity->height = '600';
+        $this->assertSame(600, $entity->image_height);
+        $this->assertIsInt($entity->image_height);
+    }
+
+    // --- Dates list ---
+
+    public function testCreatedAtIsInDatesList(): void
+    {
+        $entity     = new EventPhotoEntity();
+        $reflection = new ReflectionClass($entity);
+        $prop       = $reflection->getProperty('dates');
+        $prop->setAccessible(true);
+        $this->assertContains('created_at', $prop->getValue($entity));
+    }
+
+    public function testUpdatedAtIsInDatesList(): void
+    {
+        $entity     = new EventPhotoEntity();
+        $reflection = new ReflectionClass($entity);
+        $prop       = $reflection->getProperty('dates');
+        $prop->setAccessible(true);
+        $this->assertContains('updated_at', $prop->getValue($entity));
+    }
+
+    public function testDeletedAtIsInDatesList(): void
+    {
+        $entity     = new EventPhotoEntity();
+        $reflection = new ReflectionClass($entity);
+        $prop       = $reflection->getProperty('dates');
+        $prop->setAccessible(true);
+        $this->assertContains('deleted_at', $prop->getValue($entity));
+    }
+}

--- a/server/tests/unit/Entities/MailingEmailEntityTest.php
+++ b/server/tests/unit/Entities/MailingEmailEntityTest.php
@@ -1,0 +1,118 @@
+<?php
+
+use App\Entities\MailingEmailEntity;
+use CodeIgniter\Test\CIUnitTestCase;
+
+/**
+ * @internal
+ */
+final class MailingEmailEntityTest extends CIUnitTestCase
+{
+    // --- Constants ---
+
+    public function testStatusQueuedConstantValue(): void
+    {
+        $this->assertSame('queued', MailingEmailEntity::STATUS_QUEUED);
+    }
+
+    public function testStatusSentConstantValue(): void
+    {
+        $this->assertSame('sent', MailingEmailEntity::STATUS_SENT);
+    }
+
+    public function testStatusErrorConstantValue(): void
+    {
+        $this->assertSame('error', MailingEmailEntity::STATUS_ERROR);
+    }
+
+    public function testStatusRejectedConstantValue(): void
+    {
+        $this->assertSame('rejected', MailingEmailEntity::STATUS_REJECTED);
+    }
+
+    // --- Default attribute values ---
+
+    public function testNewInstanceDefaultLocaleIsRu(): void
+    {
+        $entity = new MailingEmailEntity();
+        $this->assertSame('ru', $entity->locale);
+    }
+
+    public function testNewInstanceDefaultStatusIsQueued(): void
+    {
+        $entity = new MailingEmailEntity();
+        $this->assertSame('queued', $entity->status);
+    }
+
+    public function testNewInstanceDefaultMailingIdIsEmpty(): void
+    {
+        // 'mailing_id' cast to 'string'; CI4 Entity converts null attribute to '' on get
+        $entity = new MailingEmailEntity();
+        $this->assertEmpty($entity->mailing_id);
+    }
+
+    public function testNewInstanceDefaultEmailIsEmpty(): void
+    {
+        // 'email' cast to 'string'; CI4 Entity converts null attribute to '' on get
+        $entity = new MailingEmailEntity();
+        $this->assertEmpty($entity->email);
+    }
+
+    public function testNewInstanceDefaultErrorMessageIsEmpty(): void
+    {
+        // 'error_message' cast to 'string'; CI4 Entity converts null attribute to '' on get
+        $entity = new MailingEmailEntity();
+        $this->assertEmpty($entity->error_message);
+    }
+
+    public function testNewInstanceDefaultSentAtIsNull(): void
+    {
+        $entity = new MailingEmailEntity();
+        $this->assertNull($entity->sent_at);
+    }
+
+    // --- Attribute assignment ---
+
+    public function testSettingEmailStoresValue(): void
+    {
+        $entity        = new MailingEmailEntity();
+        $entity->email = 'user@example.com';
+        $this->assertSame('user@example.com', $entity->email);
+    }
+
+    public function testSettingStatusToSentStoresValue(): void
+    {
+        $entity         = new MailingEmailEntity();
+        $entity->status = MailingEmailEntity::STATUS_SENT;
+        $this->assertSame('sent', $entity->status);
+    }
+
+    // --- Dates list ---
+
+    public function testSentAtIsInDatesList(): void
+    {
+        $entity     = new MailingEmailEntity();
+        $reflection = new ReflectionClass($entity);
+        $prop       = $reflection->getProperty('dates');
+        $prop->setAccessible(true);
+        $this->assertContains('sent_at', $prop->getValue($entity));
+    }
+
+    public function testCreatedAtIsInDatesList(): void
+    {
+        $entity     = new MailingEmailEntity();
+        $reflection = new ReflectionClass($entity);
+        $prop       = $reflection->getProperty('dates');
+        $prop->setAccessible(true);
+        $this->assertContains('created_at', $prop->getValue($entity));
+    }
+
+    public function testUpdatedAtIsInDatesList(): void
+    {
+        $entity     = new MailingEmailEntity();
+        $reflection = new ReflectionClass($entity);
+        $prop       = $reflection->getProperty('dates');
+        $prop->setAccessible(true);
+        $this->assertContains('updated_at', $prop->getValue($entity));
+    }
+}

--- a/server/tests/unit/Entities/ObjectEntityTest.php
+++ b/server/tests/unit/Entities/ObjectEntityTest.php
@@ -1,0 +1,67 @@
+<?php
+
+use App\Entities\ObjectEntity;
+use CodeIgniter\Test\CIUnitTestCase;
+
+/**
+ * @internal
+ */
+final class ObjectEntityTest extends CIUnitTestCase
+{
+    // --- Default attribute values ---
+
+    public function testNewInstanceRaDefaultsToZero(): void
+    {
+        // 'ra' cast to 'float'; CI4 Entity converts null attribute to 0.0 on get
+        $entity = new ObjectEntity();
+        $this->assertSame(0.0, $entity->ra);
+    }
+
+    public function testNewInstanceDecDefaultsToZero(): void
+    {
+        // 'dec' cast to 'float'; CI4 Entity converts null attribute to 0.0 on get
+        $entity = new ObjectEntity();
+        $this->assertSame(0.0, $entity->dec);
+    }
+
+    public function testNewInstanceDeletedAtDefaultsToNull(): void
+    {
+        $entity = new ObjectEntity();
+        $this->assertNull($entity->deleted_at);
+    }
+
+    // --- Cast behavior ---
+
+    public function testRaCastToFloat(): void
+    {
+        $entity     = new ObjectEntity();
+        $entity->ra = '83.8221';
+        $this->assertSame(83.8221, $entity->ra);
+        $this->assertIsFloat($entity->ra);
+    }
+
+    public function testDecCastToFloat(): void
+    {
+        $entity      = new ObjectEntity();
+        $entity->dec = '-5.3911';
+        $this->assertSame(-5.3911, $entity->dec);
+        $this->assertIsFloat($entity->dec);
+    }
+
+    public function testRaZeroCastToFloat(): void
+    {
+        $entity     = new ObjectEntity();
+        $entity->ra = '0';
+        $this->assertSame(0.0, $entity->ra);
+        $this->assertIsFloat($entity->ra);
+    }
+
+    // --- Attribute assignment ---
+
+    public function testCatalogNameStoredAsString(): void
+    {
+        $entity               = new ObjectEntity();
+        $entity->catalog_name = 'M31';
+        $this->assertSame('M31', $entity->catalog_name);
+    }
+}

--- a/server/tests/unit/Entities/ObjectFitsFileEntityTest.php
+++ b/server/tests/unit/Entities/ObjectFitsFileEntityTest.php
@@ -1,0 +1,120 @@
+<?php
+
+use App\Entities\ObjectFitsFileEntity;
+use CodeIgniter\Test\CIUnitTestCase;
+
+/**
+ * @internal
+ */
+final class ObjectFitsFileEntityTest extends CIUnitTestCase
+{
+    // --- Cast behavior (numeric) ---
+
+    public function testFileSizeCastToFloat(): void
+    {
+        $entity            = new ObjectFitsFileEntity();
+        $entity->file_size = '1048576.5';
+        $this->assertIsFloat($entity->file_size);
+        $this->assertSame(1048576.5, $entity->file_size);
+    }
+
+    public function testNaxis1CastToInt(): void
+    {
+        $entity         = new ObjectFitsFileEntity();
+        $entity->naxis1 = '4096';
+        $this->assertSame(4096, $entity->naxis1);
+        $this->assertIsInt($entity->naxis1);
+    }
+
+    public function testNaxis2CastToInt(): void
+    {
+        $entity         = new ObjectFitsFileEntity();
+        $entity->naxis2 = '2160';
+        $this->assertSame(2160, $entity->naxis2);
+        $this->assertIsInt($entity->naxis2);
+    }
+
+    public function testExptimeCastToInt(): void
+    {
+        $entity          = new ObjectFitsFileEntity();
+        $entity->exptime = '300';
+        $this->assertSame(300, $entity->exptime);
+        $this->assertIsInt($entity->exptime);
+    }
+
+    public function testGainCastToInt(): void
+    {
+        $entity       = new ObjectFitsFileEntity();
+        $entity->gain = '100';
+        $this->assertSame(100, $entity->gain);
+        $this->assertIsInt($entity->gain);
+    }
+
+    public function testRaCastToFloat(): void
+    {
+        $entity     = new ObjectFitsFileEntity();
+        $entity->ra = '83.8221';
+        $this->assertSame(83.8221, $entity->ra);
+        $this->assertIsFloat($entity->ra);
+    }
+
+    public function testDecCastToFloat(): void
+    {
+        $entity      = new ObjectFitsFileEntity();
+        $entity->dec = '-5.3911';
+        $this->assertSame(-5.3911, $entity->dec);
+        $this->assertIsFloat($entity->dec);
+    }
+
+    public function testHfrCastToFloat(): void
+    {
+        $entity      = new ObjectFitsFileEntity();
+        $entity->hfr = '2.34';
+        $this->assertIsFloat($entity->hfr);
+    }
+
+    public function testFwhmCastToFloat(): void
+    {
+        $entity       = new ObjectFitsFileEntity();
+        $entity->fwhm = '3.12';
+        $this->assertIsFloat($entity->fwhm);
+    }
+
+    public function testCcdTempCastToInt(): void
+    {
+        $entity           = new ObjectFitsFileEntity();
+        $entity->ccd_temp = '-10';
+        $this->assertSame(-10, $entity->ccd_temp);
+        $this->assertIsInt($entity->ccd_temp);
+    }
+
+    // --- Datamap aliases ---
+
+    public function testFileNameDatamapAlias(): void
+    {
+        $entity           = new ObjectFitsFileEntity();
+        $entity->fileName = 'frame_001';
+        $this->assertSame('frame_001', $entity->file_name);
+    }
+
+    public function testExposureDatamapAliasWritesToExptime(): void
+    {
+        $entity           = new ObjectFitsFileEntity();
+        $entity->exposure = '600';
+        $this->assertSame(600, $entity->exptime);
+    }
+
+    public function testCcdTempDatamapAlias(): void
+    {
+        $entity          = new ObjectFitsFileEntity();
+        $entity->ccdTemp = '-15';
+        $this->assertSame(-15, $entity->ccd_temp);
+    }
+
+    public function testDateDatamapAliasWritesToDateObs(): void
+    {
+        $entity       = new ObjectFitsFileEntity();
+        $entity->date = '2024-03-15 22:00:00';
+        $this->assertNotNull($entity->date_obs);
+    }
+}

--- a/server/tests/unit/Entities/ObjectFitsFiltersEntityTest.php
+++ b/server/tests/unit/Entities/ObjectFitsFiltersEntityTest.php
@@ -1,0 +1,63 @@
+<?php
+
+use App\Entities\ObjectFitsFiltersEntity;
+use CodeIgniter\Test\CIUnitTestCase;
+
+/**
+ * @internal
+ */
+final class ObjectFitsFiltersEntityTest extends CIUnitTestCase
+{
+    // --- Cast behavior ---
+
+    public function testFramesCountCastToInteger(): void
+    {
+        $entity               = new ObjectFitsFiltersEntity();
+        $entity->frames_count = '42';
+        $this->assertSame(42, $entity->frames_count);
+        $this->assertIsInt($entity->frames_count);
+    }
+
+    public function testExposureTimeCastToFloat(): void
+    {
+        $entity                = new ObjectFitsFiltersEntity();
+        $entity->exposure_time = '300.5';
+        $this->assertSame(300.5, $entity->exposure_time);
+        $this->assertIsFloat($entity->exposure_time);
+    }
+
+    public function testFilesSizeCastToFloat(): void
+    {
+        $entity             = new ObjectFitsFiltersEntity();
+        $entity->files_size = '2048.75';
+        $this->assertSame(2048.75, $entity->files_size);
+        $this->assertIsFloat($entity->files_size);
+    }
+
+    public function testObjectNameCastToString(): void
+    {
+        $entity              = new ObjectFitsFiltersEntity();
+        $entity->object_name = 'M42';
+        $this->assertSame('M42', $entity->object_name);
+        $this->assertIsString($entity->object_name);
+    }
+
+    public function testFilterCastToString(): void
+    {
+        $entity         = new ObjectFitsFiltersEntity();
+        $entity->filter = 'luminance';
+        $this->assertSame('luminance', $entity->filter);
+        $this->assertIsString($entity->filter);
+    }
+
+    // --- Default attribute values ---
+
+    public function testNewInstanceNumericAttributesDefaultToZero(): void
+    {
+        // cast types return zero-values for null: 'integer' → 0, 'float' → 0.0
+        $entity = new ObjectFitsFiltersEntity();
+        $this->assertSame(0, $entity->frames_count);
+        $this->assertSame(0.0, $entity->exposure_time);
+        $this->assertSame(0.0, $entity->files_size);
+    }
+}

--- a/server/tests/unit/Entities/ObservatoryEquipmentEntityTest.php
+++ b/server/tests/unit/Entities/ObservatoryEquipmentEntityTest.php
@@ -1,0 +1,76 @@
+<?php
+
+use App\Entities\ObservatoryEquipmentEntity;
+use CodeIgniter\Test\CIUnitTestCase;
+
+/**
+ * @internal
+ */
+final class ObservatoryEquipmentEntityTest extends CIUnitTestCase
+{
+    // --- Cast behavior ---
+
+    public function testIdCastToInt(): void
+    {
+        $entity     = new ObservatoryEquipmentEntity();
+        $entity->id = '3';
+        $this->assertSame(3, $entity->id);
+        $this->assertIsInt($entity->id);
+    }
+
+    public function testEquipmentTypeCastToString(): void
+    {
+        $entity                   = new ObservatoryEquipmentEntity();
+        $entity->equipment_type   = 'telescope';
+        $this->assertSame('telescope', $entity->equipment_type);
+        $this->assertIsString($entity->equipment_type);
+    }
+
+    public function testBrandCastToString(): void
+    {
+        $entity        = new ObservatoryEquipmentEntity();
+        $entity->brand = 'Celestron';
+        $this->assertSame('Celestron', $entity->brand);
+        $this->assertIsString($entity->brand);
+    }
+
+    public function testModelCastToString(): void
+    {
+        $entity        = new ObservatoryEquipmentEntity();
+        $entity->model = 'C11';
+        $this->assertSame('C11', $entity->model);
+        $this->assertIsString($entity->model);
+    }
+
+    // --- Datamap aliases ---
+
+    public function testTypeDatamapAliasWritesToEquipmentType(): void
+    {
+        $entity       = new ObservatoryEquipmentEntity();
+        $entity->type = 'camera';
+        $this->assertSame('camera', $entity->equipment_type);
+    }
+
+    public function testTypeDatamapAliasReadsFromEquipmentType(): void
+    {
+        $entity                 = new ObservatoryEquipmentEntity();
+        $entity->equipment_type = 'mount';
+        $this->assertSame('mount', $entity->type);
+    }
+
+    // --- Default attribute values ---
+
+    public function testNewInstanceIdDefaultsToZero(): void
+    {
+        // 'id' cast to 'int'; CI4 Entity converts null attribute to 0 on get
+        $entity = new ObservatoryEquipmentEntity();
+        $this->assertSame(0, $entity->id);
+    }
+
+    public function testNewInstanceBrandDefaultsToEmptyString(): void
+    {
+        // 'brand' cast to 'string'; CI4 Entity converts null attribute to '' on get
+        $entity = new ObservatoryEquipmentEntity();
+        $this->assertSame('', $entity->brand);
+    }
+}

--- a/server/tests/unit/Entities/PhotoEntityTest.php
+++ b/server/tests/unit/Entities/PhotoEntityTest.php
@@ -1,0 +1,93 @@
+<?php
+
+use App\Entities\PhotoEntity;
+use CodeIgniter\Test\CIUnitTestCase;
+
+/**
+ * @internal
+ */
+final class PhotoEntityTest extends CIUnitTestCase
+{
+    // --- Default attribute values ---
+
+    public function testNewInstanceStringAttributesDefaultToEmptyString(): void
+    {
+        // All string-cast fields return '' when the underlying attribute is null
+        $entity = new PhotoEntity();
+        $this->assertSame('', $entity->id);
+        $this->assertSame('', $entity->dir_name);
+        $this->assertSame('', $entity->file_name);
+        $this->assertSame('', $entity->file_ext);
+    }
+
+    // --- Cast behavior ---
+
+    public function testFileSizeCastToInteger(): void
+    {
+        $entity            = new PhotoEntity();
+        $entity->file_size = '2048';
+        $this->assertSame(2048, $entity->file_size);
+        $this->assertIsInt($entity->file_size);
+    }
+
+    public function testImageWidthCastToInteger(): void
+    {
+        $entity              = new PhotoEntity();
+        $entity->image_width = '1920';
+        $this->assertSame(1920, $entity->image_width);
+        $this->assertIsInt($entity->image_width);
+    }
+
+    public function testImageHeightCastToInteger(): void
+    {
+        $entity               = new PhotoEntity();
+        $entity->image_height = '1080';
+        $this->assertSame(1080, $entity->image_height);
+        $this->assertIsInt($entity->image_height);
+    }
+
+    // --- Datamap aliases ---
+
+    public function testDirNameDatamapAlias(): void
+    {
+        $entity          = new PhotoEntity();
+        $entity->dirName = 'photos/2024';
+        $this->assertSame('photos/2024', $entity->dir_name);
+    }
+
+    public function testFileNameDatamapAlias(): void
+    {
+        $entity           = new PhotoEntity();
+        $entity->fileName = 'orion_nebula';
+        $this->assertSame('orion_nebula', $entity->file_name);
+    }
+
+    public function testFileExtDatamapAlias(): void
+    {
+        $entity          = new PhotoEntity();
+        $entity->fileExt = 'jpg';
+        $this->assertSame('jpg', $entity->file_ext);
+    }
+
+    public function testFileSizeDatamapAliasAppliesIntCast(): void
+    {
+        $entity           = new PhotoEntity();
+        $entity->fileSize = '4096';
+        $this->assertSame(4096, $entity->file_size);
+        $this->assertIsInt($entity->file_size);
+    }
+
+    public function testImageWidthDatamapAlias(): void
+    {
+        $entity             = new PhotoEntity();
+        $entity->imageWidth = '3840';
+        $this->assertSame(3840, $entity->image_width);
+    }
+
+    public function testImageHeightDatamapAlias(): void
+    {
+        $entity              = new PhotoEntity();
+        $entity->imageHeight = '2160';
+        $this->assertSame(2160, $entity->image_height);
+    }
+}

--- a/server/tests/unit/Helpers/AuthHelperTest.php
+++ b/server/tests/unit/Helpers/AuthHelperTest.php
@@ -68,4 +68,38 @@ final class AuthHelperTest extends CIUnitTestCase
         $parts = explode('.', $token);
         $this->assertCount(3, $parts, 'JWT should have exactly 3 dot-separated parts');
     }
+
+    public function testGenerateAuthTokenDifferentEmailsProduceDifferentTokens(): void
+    {
+        $token1 = generateAuthToken('alice@example.com');
+        $token2 = generateAuthToken('bob@example.com');
+        $this->assertNotSame($token1, $token2);
+    }
+
+    // --- validateAuthToken() tests ---
+
+    public function testValidateAuthTokenWithNullReturnsNull(): void
+    {
+        $result = validateAuthToken(null);
+        $this->assertNull($result);
+    }
+
+    public function testValidateAuthTokenWithEmptyStringReturnsNull(): void
+    {
+        $result = validateAuthToken('');
+        $this->assertNull($result);
+    }
+
+    public function testValidateAuthTokenWithInvalidTokenReturnsNull(): void
+    {
+        // JWT::decode throws for a malformed token; the helper catches \Throwable
+        $result = validateAuthToken('this.is.notvalid');
+        $this->assertNull($result);
+    }
+
+    public function testValidateAuthTokenWithArbitraryStringReturnsNull(): void
+    {
+        $result = validateAuthToken('not-a-jwt-at-all');
+        $this->assertNull($result);
+    }
 }

--- a/server/tests/unit/Models/ApplicationBaseModelTest.php
+++ b/server/tests/unit/Models/ApplicationBaseModelTest.php
@@ -110,4 +110,62 @@ final class ApplicationBaseModelTest extends CIUnitTestCase
 
         $reflection->setValue($this->model, []);
     }
+
+    public function testPrepareOutputHidesSpecifiedFieldFromFirstResult(): void
+    {
+        $reflection = new ReflectionProperty($this->model, 'hiddenFields');
+        $reflection->setAccessible(true);
+        $reflection->setValue($this->model, ['token']);
+
+        $data = [
+            'method' => 'first',
+            'data'   => ['email' => 'user@example.com', 'token' => 'secret-token'],
+        ];
+
+        $result = $this->model->prepareOutput($data);
+        $this->assertArrayNotHasKey('token', $result['data']);
+        $this->assertArrayHasKey('email', $result['data']);
+
+        $reflection->setValue($this->model, []);
+    }
+
+    public function testPrepareOutputHidesMultipleFieldsFromFindAllResult(): void
+    {
+        $reflection = new ReflectionProperty($this->model, 'hiddenFields');
+        $reflection->setAccessible(true);
+        $reflection->setValue($this->model, ['password', 'token']);
+
+        $data = [
+            'method' => 'findAll',
+            'data'   => [
+                ['name' => 'Alice', 'password' => 'hash1', 'token' => 'tkn1'],
+                ['name' => 'Bob',   'password' => 'hash2', 'token' => 'tkn2'],
+            ],
+        ];
+
+        $result = $this->model->prepareOutput($data);
+
+        foreach ($result['data'] as $row) {
+            $this->assertArrayNotHasKey('password', $row);
+            $this->assertArrayNotHasKey('token', $row);
+            $this->assertArrayHasKey('name', $row);
+        }
+
+        $reflection->setValue($this->model, []);
+    }
+
+    public function testGenerateIdProducesUniqueIdsOnRepeatedCalls(): void
+    {
+        $result1 = $this->generateIdMethod->invoke($this->model, ['data' => []]);
+        $result2 = $this->generateIdMethod->invoke($this->model, ['data' => []]);
+
+        $this->assertNotSame($result1['data']['id'], $result2['data']['id']);
+    }
+
+    public function testGenerateIdOverwritesExistingIdInData(): void
+    {
+        $result = $this->generateIdMethod->invoke($this->model, ['data' => ['id' => 'old-id', 'name' => 'test']]);
+        $this->assertNotSame('old-id', $result['data']['id']);
+        $this->assertSame('test', $result['data']['name']);
+    }
 }

--- a/server/tests/unit/Models/CommentsModelTest.php
+++ b/server/tests/unit/Models/CommentsModelTest.php
@@ -1,0 +1,253 @@
+<?php
+
+use App\Models\CommentsModel;
+use CodeIgniter\Test\CIUnitTestCase;
+
+/**
+ * Tests for CommentsModel private helper methods via reflection.
+ * No database connection is needed — pure unit tests.
+ *
+ * @internal
+ */
+final class CommentsModelTest extends CIUnitTestCase
+{
+    private CommentsModel $model;
+    private ReflectionMethod $truncateMethod;
+    private ReflectionMethod $formatRowsMethod;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->model = new CommentsModel();
+
+        $this->truncateMethod = new ReflectionMethod($this->model, 'truncateAuthorName');
+        $this->truncateMethod->setAccessible(true);
+
+        $this->formatRowsMethod = new ReflectionMethod($this->model, 'formatRows');
+        $this->formatRowsMethod->setAccessible(true);
+    }
+
+    // --- truncateAuthorName() tests ---
+
+    public function testTruncateAuthorNameEmptyStringReturnsEmptyString(): void
+    {
+        $result = $this->truncateMethod->invoke($this->model, '');
+        $this->assertSame('', $result);
+    }
+
+    public function testTruncateAuthorNameWhitespaceOnlyReturnsEmptyString(): void
+    {
+        $result = $this->truncateMethod->invoke($this->model, '   ');
+        $this->assertSame('', $result);
+    }
+
+    public function testTruncateAuthorNameSingleWordReturnedUnchanged(): void
+    {
+        $result = $this->truncateMethod->invoke($this->model, 'Alice');
+        $this->assertSame('Alice', $result);
+    }
+
+    public function testTruncateAuthorNameTwoWordsReturnFirstNameWithLastInitial(): void
+    {
+        $result = $this->truncateMethod->invoke($this->model, 'Alice Smith');
+        $this->assertSame('Alice S.', $result);
+    }
+
+    public function testTruncateAuthorNameCyrillicTwoWordsReturnFirstNameWithLastInitial(): void
+    {
+        $result = $this->truncateMethod->invoke($this->model, 'Иван Петров');
+        $this->assertSame('Иван П.', $result);
+    }
+
+    public function testTruncateAuthorNameThreeWordsUsesFirstAndSecondWordInitial(): void
+    {
+        // explode on space gives [$first, $second, $third]; only $parts[1] is used
+        $result = $this->truncateMethod->invoke($this->model, 'Alice Mary Smith');
+        $this->assertSame('Alice M.', $result);
+    }
+
+    public function testTruncateAuthorNameLastNameSingleCharReturnedCorrectly(): void
+    {
+        $result = $this->truncateMethod->invoke($this->model, 'Bob X');
+        $this->assertSame('Bob X.', $result);
+    }
+
+    // --- formatRows() tests (keepEntity = false, default) ---
+
+    public function testFormatRowsEmptyInputReturnsEmptyArray(): void
+    {
+        $result = $this->formatRowsMethod->invoke($this->model, []);
+        $this->assertSame([], $result);
+    }
+
+    public function testFormatRowsBuildsCreatedAtFromCreatedAtField(): void
+    {
+        $rows = [
+            [
+                'id'          => 'cmt-1',
+                'user_id'     => 'usr-1',
+                'entity_type' => 'event',
+                'entity_id'   => 'evt-1',
+                'content'     => 'Great event!',
+                'rating'      => 5,
+                'status'      => 'visible',
+                'created_at'  => '2024-05-01 10:00:00',
+                'author_name' => 'Alice Smith',
+                'avatar'      => 'alice.jpg',
+            ],
+        ];
+
+        $result = $this->formatRowsMethod->invoke($this->model, $rows);
+
+        $this->assertArrayHasKey('createdAt', $result[0]);
+        $this->assertSame('2024-05-01 10:00:00', $result[0]['createdAt']);
+    }
+
+    public function testFormatRowsBuildsAuthorObject(): void
+    {
+        $rows = [
+            [
+                'id'          => 'cmt-1',
+                'user_id'     => 'usr-42',
+                'entity_type' => 'event',
+                'entity_id'   => 'evt-1',
+                'content'     => 'Lovely!',
+                'rating'      => 4,
+                'status'      => 'visible',
+                'created_at'  => '2024-05-01 10:00:00',
+                'author_name' => 'Bob Jones',
+                'avatar'      => 'bob.png',
+            ],
+        ];
+
+        $result = $this->formatRowsMethod->invoke($this->model, $rows);
+        $author = $result[0]['author'];
+
+        $this->assertSame('usr-42', $author['id']);
+        $this->assertSame('Bob J.', $author['name']);
+        $this->assertSame('bob.png', $author['avatar']);
+    }
+
+    public function testFormatRowsRemovesRawDbFields(): void
+    {
+        $rows = [
+            [
+                'id'          => 'cmt-1',
+                'user_id'     => 'usr-1',
+                'entity_type' => 'event',
+                'entity_id'   => 'evt-1',
+                'content'     => 'Nice.',
+                'rating'      => 3,
+                'status'      => 'visible',
+                'created_at'  => '2024-01-01 00:00:00',
+                'author_name' => 'Alice Smith',
+                'avatar'      => null,
+            ],
+        ];
+
+        $result = $this->formatRowsMethod->invoke($this->model, $rows);
+
+        $this->assertArrayNotHasKey('created_at', $result[0]);
+        $this->assertArrayNotHasKey('author_name', $result[0]);
+        $this->assertArrayNotHasKey('avatar', $result[0]);
+        $this->assertArrayNotHasKey('user_id', $result[0]);
+        $this->assertArrayNotHasKey('entity_type', $result[0]);
+        $this->assertArrayNotHasKey('entity_id', $result[0]);
+        $this->assertArrayNotHasKey('status', $result[0]);
+    }
+
+    public function testFormatRowsWithoutKeepEntityDoesNotExposeEntityFields(): void
+    {
+        $rows = [
+            [
+                'id'          => 'cmt-1',
+                'user_id'     => 'usr-1',
+                'entity_type' => 'event',
+                'entity_id'   => 'evt-1',
+                'content'     => 'Nice.',
+                'rating'      => 3,
+                'status'      => 'visible',
+                'created_at'  => '2024-01-01 00:00:00',
+                'author_name' => 'Alice Smith',
+                'avatar'      => null,
+            ],
+        ];
+
+        $result = $this->formatRowsMethod->invoke($this->model, $rows, false);
+
+        $this->assertArrayNotHasKey('entityType', $result[0]);
+        $this->assertArrayNotHasKey('entityId', $result[0]);
+    }
+
+    public function testFormatRowsWithKeepEntityExposesEntityTypeAndEntityId(): void
+    {
+        $rows = [
+            [
+                'id'          => 'cmt-2',
+                'user_id'     => 'usr-7',
+                'entity_type' => 'photo',
+                'entity_id'   => 'ph-99',
+                'content'     => 'Beautiful shot.',
+                'rating'      => 5,
+                'status'      => 'visible',
+                'created_at'  => '2024-06-01 12:00:00',
+                'author_name' => 'Vera Long',
+                'avatar'      => null,
+            ],
+        ];
+
+        $result = $this->formatRowsMethod->invoke($this->model, $rows, true);
+
+        $this->assertArrayHasKey('entityType', $result[0]);
+        $this->assertArrayHasKey('entityId', $result[0]);
+        $this->assertSame('photo', $result[0]['entityType']);
+        $this->assertSame('ph-99', $result[0]['entityId']);
+    }
+
+    public function testFormatRowsMultipleRowsAreAllFormatted(): void
+    {
+        $makeRow = static fn (string $id, string $name): array => [
+            'id'          => $id,
+            'user_id'     => 'usr-' . $id,
+            'entity_type' => 'event',
+            'entity_id'   => 'evt-1',
+            'content'     => 'text',
+            'rating'      => 5,
+            'status'      => 'visible',
+            'created_at'  => '2024-01-01 00:00:00',
+            'author_name' => $name,
+            'avatar'      => null,
+        ];
+
+        $result = $this->formatRowsMethod->invoke($this->model, [
+            $makeRow('c1', 'Alice Smith'),
+            $makeRow('c2', 'Bob Jones'),
+        ]);
+
+        $this->assertCount(2, $result);
+        $this->assertSame('Alice S.', $result[0]['author']['name']);
+        $this->assertSame('Bob J.', $result[1]['author']['name']);
+    }
+
+    public function testFormatRowsAuthorAvatarNullWhenMissing(): void
+    {
+        $rows = [
+            [
+                'id'          => 'cmt-1',
+                'user_id'     => 'usr-1',
+                'entity_type' => 'event',
+                'entity_id'   => 'evt-1',
+                'content'     => 'text',
+                'rating'      => 4,
+                'status'      => 'visible',
+                'created_at'  => '2024-01-01 00:00:00',
+                'author_name' => 'Alice',
+                'avatar'      => null,
+            ],
+        ];
+
+        $result = $this->formatRowsMethod->invoke($this->model, $rows);
+        $this->assertNull($result[0]['author']['avatar']);
+    }
+}


### PR DESCRIPTION
### Patch Changes

- Enhanced SEO metadata in `AppLayout`: canonical URL is now computed from `SITE_LINK` + path and honored even when set to an empty string; added `languageAlternates` (ru, en, x-default) when a canonical is present; set Open Graph type to `"website"` and default Twitter card to `"summary_large_image"`
- Added `BreadcrumbList` JSON-LD structured data to `AppToolbar`: breadcrumb URLs are built with locale prefix (`en/` for English), home title is translated, and the schema is injected into `<Head>` via `dangerouslySetInnerHTML`
- Added `Organization` JSON-LD structured data in `_app.tsx` (name, URL, logo, sameAs links); added canonical prop to the homepage; added homepage URL nodes (`''` and `en/`) to the sitemap with monthly cadence; extended `robots.txt` with Disallow rules for English routes, profile/unsubscribe pages, and stargazing statistic paths
- Added schema.org `Event` JSON-LD to stargazing event detail pages (`/stargazing/[name]`): includes name, description, startDate, location, organizer, image, and URL; injected via `next/head` when event data is available
- Added schema.org `FAQPage` JSON-LD to the stargazing FAQ page (`/stargazing/faq`): built from localized translation strings and injected via `next/head`
- Extended `AuthGuardTest` with additional 401 checks covering photos (`PATCH`/`DELETE`), events (`POST`/`PATCH`/`DELETE`), comments (`POST`/`DELETE`), members endpoints, and mailings (`POST`/`DELETE`)
- Added `CategoryEntityTest` and `EventPhotoEntityTest`: verify attribute casting, default values, datamap aliases, and that `created_at`/`updated_at`/`deleted_at` are included in the dates list
- Added `MailingEmailEntityTest`, `ObjectEntityTest`, and `ObjectFitsFileEntityTest`: cover constant values, default attributes, type casting, date field inclusion, and datamap aliases
- Added `PhotoEntityTest`, `ObservatoryEquipmentEntityTest`, and `ObjectFitsFiltersEntityTest`: verify int/float/string casts, default values for new instances, and datamap alias behavior
- Expanded `AuthHelperTest` with edge-case coverage: `generateAuthToken` produces different tokens for different emails; `validateAuthToken` returns `null` for `null`, empty, malformed, or arbitrary non-JWT strings
- Extended `ApplicationBaseModelTest` with tests for `prepareOutput` field-hiding (`first`/`findAll`) and `generateId` uniqueness and overwrite behavior; added `CommentsModelTest` (reflection-based, no DB) covering private helpers `truncateAuthorName` (empty, whitespace, single/multi-word, Cyrillic, initials) and `formatRows` (camelCase mapping, author object, avatar URL, raw DB field removal, `keepEntity` flag, multi-row formatting)