### PR TITLE
Disable Google OAuth in login form

### DIFF
--- a/client/components/common/login-form/LoginForm.tsx
+++ b/client/components/common/login-form/LoginForm.tsx
@@ -11,7 +11,7 @@ import useLocalStorage from '@/hooks/useLocalStorage'
 import googleLogo from '@/public/images/google-logo.png'
 import vkLogo from '@/public/images/vk-logo.png'
 import yandexLogo from '@/public/images/yandex-logo.png'
-import { LOCAL_STORAGE } from '@/utils/constants'
+import { AUTH_GOOGLE_ENABLED, LOCAL_STORAGE } from '@/utils/constants'
 
 import styles from './styles.module.sass'
 
@@ -35,7 +35,7 @@ export const LoginForm: React.FC<LoginFormProps> = ({ onError }) => {
 
     // Whitelist of trusted OAuth provider origins
     const OAUTH_ALLOWED_ORIGINS = [
-        'https://accounts.google.com',
+        ...(AUTH_GOOGLE_ENABLED ? ['https://accounts.google.com'] : []),
         'https://oauth.yandex.com',
         'https://oauth.yandex.ru',
         'https://oauth.vk.com',
@@ -87,18 +87,20 @@ export const LoginForm: React.FC<LoginFormProps> = ({ onError }) => {
                     />
                 </Button>
 
-                <Button
-                    mode={'outline'}
-                    disabled={isLoading}
-                    onClick={() => handleLoginServiceButton('google')}
-                >
-                    <Image
-                        src={googleLogo.src}
-                        width={40}
-                        height={40}
-                        alt={''}
-                    />
-                </Button>
+                {AUTH_GOOGLE_ENABLED && (
+                    <Button
+                        mode={'outline'}
+                        disabled={isLoading}
+                        onClick={() => handleLoginServiceButton('google')}
+                    >
+                        <Image
+                            src={googleLogo.src}
+                            width={40}
+                            height={40}
+                            alt={''}
+                        />
+                    </Button>
+                )}
 
                 <Button
                     mode={'outline'}

--- a/client/utils/constants.ts
+++ b/client/utils/constants.ts
@@ -20,3 +20,8 @@ export const STARGAZING_LEGACY_MEMBERS = 50000
 // The community has been running astronomy activities since this year; used to
 // derive the "years in astronomy" counter (chosen so it currently reads 11).
 export const STARGAZING_FOUNDING_YEAR = 2015
+
+// Google OAuth is disabled to comply with Russian Federation legislation
+// (foreign authentication services restriction effective March 2025).
+// Set to true to re-enable the Google login button.
+export const AUTH_GOOGLE_ENABLED = false


### PR DESCRIPTION
Adds an `AUTH_GOOGLE_ENABLED` feature flag (default `false`) and wires the login UI to hide Google auth when disabled. The Google logo import and allowed OAuth origins are now conditional, so only enabled providers are rendered and trusted.